### PR TITLE
[REFACTOR] Added WinnerButton Component

### DIFF
--- a/src/components/ui/WinnerButton.tsx
+++ b/src/components/ui/WinnerButton.tsx
@@ -1,0 +1,18 @@
+import { ButtonHTMLAttributes } from "react";
+import clsx from "clsx";
+
+export function WinnerButton({
+    className, // pulls out className separately
+    ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+    return (
+        <button
+            className={clsx(
+                "bg-blue-600 text-white px-6 py-3 w-full hover:bg-blue-700", // default styles for winner button
+                className
+                // merge any custom classes passed in | right now none present in case any new style or re use of this button 
+            )}
+            {...props}
+        />
+    );
+}

--- a/src/modals/WinnerModal.tsx
+++ b/src/modals/WinnerModal.tsx
@@ -1,7 +1,8 @@
 import { useRouter } from "next/navigation";
 import { WinnerModalProps } from "@/services/types";
+import { WinnerButton } from "@/components/ui/WinnerButton";
 
-const WinnerModal = ({ visible, winner, onPlayAgain}: WinnerModalProps) => {
+const WinnerModal = ({ visible, winner, onPlayAgain }: WinnerModalProps) => {
   if (!visible) return null;
   const router = useRouter();
   const exitToMenu = () => {
@@ -16,19 +17,12 @@ const WinnerModal = ({ visible, winner, onPlayAgain}: WinnerModalProps) => {
         </p>
 
         <div className="flex justify-between gap-4 w-full">
-          <button
-            onClick={onPlayAgain}
-            className="bg-blue-600 text-white px-6 py-3 w-full hover:bg-blue-700"
-          >
+          <WinnerButton onClick={onPlayAgain}>
             Play Again
-          </button>
-
-          <button
-            onClick={exitToMenu}
-            className="bg-blue-600 text-white px-6 py-3 w-full hover:bg-blue-700"
-          >
+          </WinnerButton>
+          <WinnerButton onClick={exitToMenu}>
             Main Menu
-          </button>
+          </WinnerButton>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description
- The current codebase uses inline Tailwind utility classes directly within the JSX (e.g., className="bg-blue-600 py-4 text-white text-[30px]").

### This results in:

- Visual bloat in the component files
- Repetition across files (Settings, Reset, Main Menu buttons, etc.)
- Difficulty maintaining consistent design
- Doesnt Follow the Princpiles of DRY

This Issue is for `src/Modals/WinnerModal.tsx` and adds **WinnerModalButton** Component and is a _MINOR REFACTOR_

<img width="957" height="329" alt="Image" src="https://github.com/user-attachments/assets/a2601aa1-9b0f-4334-b758-51262fc03856" />

closes #76 