### PR TITLE
[Refactor] Extract and Standardize Common UI Components with Internal Tailwind Styling

### DIFF
--- a/src/components/ui/Buttons/SoundConfigButton.tsx
+++ b/src/components/ui/Buttons/SoundConfigButton.tsx
@@ -1,0 +1,12 @@
+import { ButtonHTMLAttributes } from "react";
+
+export function SoundConfigButton({
+    ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+    return (
+        <button
+            className={"bg-blue-600 hover:bg-blue-700 text-white  py-3 text-xl flex-1"}
+            {...props}
+        />
+    );
+}

--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -1,0 +1,12 @@
+import { ButtonHTMLAttributes } from "react";
+
+export function SoundMuteButton({
+    ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+    return (
+        <button
+            className={"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 text-l"}
+            {...props}
+        />
+    );
+}

--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -5,7 +5,7 @@ export function SoundMuteButton({
 }: ButtonHTMLAttributes<HTMLButtonElement>) {
     return (
         <button
-            className={"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 text-l"}
+            className={"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 text-lg"}
             {...props}
         />
     );

--- a/src/modals/SoundConfigModal.tsx
+++ b/src/modals/SoundConfigModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { SoundMuteButton } from "@/components/ui/Buttons/SoundMuteButton";
+import { SoundConfigButton } from "@/components/ui/Buttons/SoundConfigButton";
 import { useSound } from "@/services/store";
 
 type SoundConfigModalProps = {
@@ -69,18 +70,16 @@ export default function SoundConfigModal({ visible, onClose }: SoundConfigModalP
 
                 {/* Controls */}
                 <div className="mt-6 flex flex-wrap gap-3 justify-center">
-                    <button
+                    <SoundConfigButton
                         onClick={resetSounds}
-                        className="bg-blue-600 hover:bg-blue-700 text-white py-3 text-xl flex-1"
                     >
                         Reset Sounds
-                    </button>
-                    <button
+                    </SoundConfigButton>
+                    <SoundConfigButton
                         onClick={onClose}
-                        className=""
                     >
                         Return
-                    </button>
+                    </SoundConfigButton>
                 </div>
             </div>
         </div>

--- a/src/modals/SoundConfigModal.tsx
+++ b/src/modals/SoundConfigModal.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { SoundMuteButton } from "@/components/ui/Buttons/SoundMuteButton";
 import { useSound } from "@/services/store";
 
 type SoundConfigModalProps = {
@@ -39,12 +40,11 @@ export default function SoundConfigModal({ visible, onClose }: SoundConfigModalP
                         onChange={(e) => setBgVolume(Number(e.target.value) / 100)}
                         className="flex-2 mx-2 accent-[#0055ff]"
                     />
-                    <button
+                    <SoundMuteButton
                         onClick={() => setBgMute(!bgMute)}
-                        className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 text-lg"
                     >
                         {bgMute ? "Unmute" : "Mute"}
-                    </button>
+                    </SoundMuteButton>
                 </div>
 
                 {/* Player Move */}
@@ -60,12 +60,11 @@ export default function SoundConfigModal({ visible, onClose }: SoundConfigModalP
                         onChange={(e) => setSfxVolume(Number(e.target.value) / 100)}
                         className="flex-2 mx-2 accent-[#0055ff]"
                     />
-                    <button
+                    <SoundMuteButton
                         onClick={() => setSfxMute(!sfxMute)}
-                        className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 text-lg"
                     >
                         {sfxMute ? "Unmute" : "Mute"}
-                    </button>
+                    </SoundMuteButton>
                 </div>
 
                 {/* Controls */}
@@ -78,7 +77,7 @@ export default function SoundConfigModal({ visible, onClose }: SoundConfigModalP
                     </button>
                     <button
                         onClick={onClose}
-                        className="bg-blue-600 hover:bg-blue-700 text-white  py-3 text-xl flex-1"
+                        className=""
                     >
                         Return
                     </button>


### PR DESCRIPTION
### Description
- The current codebase uses inline Tailwind utility classes directly within the JSX (e.g., className="bg-blue-600 py-4 text-white text-[30px]").

### This results in:

- Visual bloat in the component files
- Repetition across files (Settings, Reset, Main Menu buttons, etc.)
- Difficulty maintaining consistent design
- Doesnt Follow the Princpiles of DRY

This Issue adds `MuteButton` and `SoundControlButton.tsx` to **SoundConfigModal.tsx** Component and is a _MINOR REFACTOR_

closes #140 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added dedicated buttons for Sound Settings actions (Mute Background Music, Mute Move Sound, Reset Sounds, Return) for a clearer, more consistent UI.

- Refactor
  - Replaced inline buttons in the Sound Settings modal with reusable components to centralize styling.

- Style
  - Unified button styling (colors, sizes, spacing) across the Sound Settings modal for improved consistency and readability and enhanced visual hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->