### PR TITLE
[ENHANCEMENT] Shortcut Modal Design

### DIFF
--- a/src/app/Menu.tsx
+++ b/src/app/Menu.tsx
@@ -10,6 +10,7 @@ import MenuContainer from '@/components/ui/Containers/Menu/MenuContainer';
 import MenuButtonContainer from '@/components/ui/Containers/Menu/MenuButtonContainer';
 import { MenuTitle } from '@/components/ui/Title/MenuTitle';
 import SoundConfigModal from '@/modals/SoundConfigModal';
+import ShortcutModal from '@/modals/ShortcutModal';
 import { useState } from 'react';
 const Menu = () => {
   const user = useUser((state) => state.user);
@@ -19,6 +20,7 @@ const Menu = () => {
   const router = useRouter();
   const { canShowToast, triggerToastCooldown, resetCooldown } = useToastCooldown(4000);
   const [showSoundConfig, setShowSoundConfig] = useState<boolean>(false);
+  const [showShortcutConfig, setshowShortcutConfig] = useState<boolean>(false);
 
   const handleSignIn = async () => {
     try {
@@ -61,8 +63,10 @@ const Menu = () => {
         <MenuButton onClick={() => setShowTut(true)}> Tutorial </MenuButton>
         <MenuButton onClick={(user) ? handleSignOut : handleSignIn}>{(user) ? "Sign Out" : "Sign in"}</MenuButton>
         <MenuButton onClick={() => setShowSoundConfig(!showSoundConfig)}>Adjust Sound</MenuButton>
+        <MenuButton onClick={() => setshowShortcutConfig(!showShortcutConfig)}>Keyboard Shortcuts</MenuButton>
       </MenuButtonContainer >
       <SoundConfigModal visible={showSoundConfig} onClose={() => setShowSoundConfig(false)} />
+      <ShortcutModal visible={showShortcutConfig} onClose={() => setshowShortcutConfig(false)} />
     </MenuContainer >
   );
 };

--- a/src/modals/ShortcutModal.tsx
+++ b/src/modals/ShortcutModal.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+type ShortcutModalProps = {
+    visible: boolean;
+    onClose: () => void;
+};
+
+export default function ShortcutModal({ visible, onClose }: ShortcutModalProps) {
+    if (!visible) return null;
+
+    const shortcuts = [
+        { key: 'Esc', action: 'Close the modal / pause menu' },
+        { key: 'R', action: 'Reset the game' },
+        { key: 'N', action: 'Reset player names' },
+        { key: 'C', action: 'Open game configuration' },
+        { key: 'M', action: 'Go to main menu' },
+        { key: 'S', action: 'Adjust sound' },
+        { key: 'Enter', action: 'Return to game' },
+    ];
+
+    return (
+        <div className="fixed inset-0 bg-black/80 flex justify-center items-center z-50">
+            <div className="bg-black p-6 w-[90%] max-w-xl space-y-6 text-center text-white">
+                <h2 className="text-red-500 text-[35px] mb-4">Keyboard Shortcuts</h2>
+
+                <div className="grid grid-cols-2 gap-4 text-left">
+                    {shortcuts.map((shortcut) => (
+                        <div key={shortcut.key} className="flex flex-col items-start">
+                            <h4 className="font-extrabold text-xl">{shortcut.key}</h4>
+                            <p className="text-lg text-gray-300">{shortcut.action}</p>
+                        </div>
+                    ))}
+                </div>
+
+                <button
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
+                    onClick={onClose}
+                >
+                    Return
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/modals/ShortcutModal.tsx
+++ b/src/modals/ShortcutModal.tsx
@@ -20,8 +20,14 @@ export default function ShortcutModal({ visible, onClose }: ShortcutModalProps) 
 
     return (
         <div className="fixed inset-0 bg-black/80 flex justify-center items-center z-50">
-            <div className="bg-black p-6 w-[90%] max-w-md space-y-6  text-white">
-                <h2 className="text-red-500 text-4xl mb-6">Keyboard Shortcuts</h2>
+            <div className="bg-black p-6 w-[90%] max-w-md space-y-6 text-white rounded-xl shadow-lg">
+                <h2 className="text-red-500 text-4xl mb-2">Keyboard Shortcuts</h2>
+
+                {/* Pending notice */}
+                <div className="bg-yellow-500/20 border border-yellow-500 text-yellow-400 p-3 rounded-lg text-md">
+                    ⚠️ NOTE : These shortcuts are for reference only. Implementation is pending, so they
+                    won’t work right now.
+                </div>
 
                 <div className="grid grid-cols-2 gap-4 text-left">
                     {shortcuts.map((shortcut) => (
@@ -33,7 +39,7 @@ export default function ShortcutModal({ visible, onClose }: ShortcutModalProps) 
                 </div>
 
                 <button
-                    className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4 rounded-lg"
                     onClick={onClose}
                 >
                     Return

--- a/src/modals/ShortcutModal.tsx
+++ b/src/modals/ShortcutModal.tsx
@@ -20,8 +20,8 @@ export default function ShortcutModal({ visible, onClose }: ShortcutModalProps) 
 
     return (
         <div className="fixed inset-0 bg-black/80 flex justify-center items-center z-50">
-            <div className="bg-black p-6 w-[90%] max-w-xl space-y-6 text-center text-white">
-                <h2 className="text-red-500 text-[35px] mb-4">Keyboard Shortcuts</h2>
+            <div className="bg-black p-6 w-[90%] max-w-md space-y-6  text-white">
+                <h2 className="text-red-500 text-4xl mb-6">Keyboard Shortcuts</h2>
 
                 <div className="grid grid-cols-2 gap-4 text-left">
                     {shortcuts.map((shortcut) => (


### PR DESCRIPTION
Description : Design of the Modal

---

**Task: Create the basic design for the shortcut display modal (layout, open/close, style).
and also adds a button in home page to open the shortcuts modal** 

---

Goal: Make it reusable, responsive, and easy to extend later.

---

<img width="1904" height="967" alt="image" src="https://github.com/user-attachments/assets/b1ef45db-394f-4529-8536-87e57e4f2d70" />

closes #146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Keyboard Shortcuts modal accessible from the app menu.
  * Presents a clear, two-column list of shortcut keys and their actions for quick reference.
  * Full-screen translucent overlay with a centered, dismissible panel and a Return button.
  * Can be opened from the menu and closes without affecting existing settings or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->