### PR TITLE
Music: only play background after user gesture unlock; keep init without autoplay

### DIFF
--- a/src/components/MusicProvider.tsx
+++ b/src/components/MusicProvider.tsx
@@ -8,7 +8,8 @@ import {
   setBackgroundVolume,
   stopBackgroundMusic,
   setMoveVolume,
-  setWinVolume
+  setWinVolume,
+  isAudioUnlocked
 } from "@/services/sounds";
 
 export default function MusicProvider() {
@@ -28,7 +29,10 @@ export default function MusicProvider() {
       // mute is setting the volume down
       setBackgroundVolume(0)
     } else {
-      playBackgroundMusic();
+      // Only try to play if audio is unlocked by a user gesture
+      if (isAudioUnlocked()) {
+        playBackgroundMusic();
+      }
       setBackgroundVolume(bgVolume);
     }
   }, [bgMute, bgVolume]);

--- a/src/services/sounds.ts
+++ b/src/services/sounds.ts
@@ -3,6 +3,28 @@ let backgroundAudio: HTMLAudioElement | null = null;
 let moveAudio: HTMLAudioElement | null = null;
 let winAudio: HTMLAudioElement | null = null;
 
+// Simple user-gesture unlock tracking so we can gate background music
+let audioUnlocked = false;
+let unlockListenersInitialized = false;
+
+const setupAudioUnlockListeners = () => {
+  if (unlockListenersInitialized || typeof window === 'undefined') return;
+  unlockListenersInitialized = true;
+
+  const handleFirstInteraction = () => {
+    audioUnlocked = true;
+    document.removeEventListener('click', handleFirstInteraction);
+    document.removeEventListener('touchstart', handleFirstInteraction);
+    document.removeEventListener('keydown', handleFirstInteraction);
+  };
+
+  document.addEventListener('click', handleFirstInteraction);
+  document.addEventListener('touchstart', handleFirstInteraction);
+  document.addEventListener('keydown', handleFirstInteraction);
+};
+
+export const isAudioUnlocked = () => audioUnlocked;
+
 export const playMoveSound = (mute: boolean) => {
   if (mute) return;
   if (!moveAudio) {
@@ -42,6 +64,8 @@ export const initBackgroundMusic = () => {
   backgroundAudio.volume = 0.3;
 
   // This doesnt autoplay .. jus intialises itself
+  // Also prepare unlock listeners so MusicProvider can check isAudioUnlocked()
+  setupAudioUnlockListeners();
 };
 
 export const playBackgroundMusic = () => {


### PR DESCRIPTION
This pull request updates the `MusicProvider` component to improve how background music playback is handled, specifically addressing browser restrictions on autoplay. The main change ensures that background music only starts if the user has interacted with the page, preventing unwanted playback and potential errors.

Audio playback control:

* Imported the `isAudioUnlocked` function from `@/services/sounds` to check if audio can be played based on user interaction.
* Updated the logic in `MusicProvider` so that `playBackgroundMusic()` is only called when audio is unlocked by a user gesture, improving compliance with browser autoplay policies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background music now starts only after you interact (tap/click/keypress), providing user-controlled playback. Volume behavior remains unchanged after start.

* **Bug Fixes**
  * Prevents unintended autoplay of background music on page load, improving compliance with browser policies and avoiding surprise audio across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->