### PR TITLE
Add unit test for Menu buttons rendering (issue #190)

### DIFF
--- a/__tests__/menu.test.tsx
+++ b/__tests__/menu.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Required mocks
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/services/firebase", () => ({
+  signInWithGoogle: vi.fn(),
+  signOutUser: vi.fn(),
+}));
+
+vi.mock("@/services/store", () => ({
+    useUser: (selector: any) => selector({ user: null, setUser: vi.fn() }),
+    useTut: (selector: any) => selector({ setShowTut: vi.fn() }),
+    useSound: () => ({
+      bgMute: false,
+      bgVolume: 0.5,
+      setBgMute: vi.fn(),
+      setBgVolume: vi.fn(),
+      sfxMute: false,
+      sfxVolume: 0.5,
+      setSfxMute: vi.fn(),
+      setSfxVolume: vi.fn(),
+    }),
+  }));
+  
+
+vi.mock("@/components/hooks/useToastCooldown", () => ({
+  useToastCooldown: () => ({
+    canShowToast: () => true,
+    triggerToastCooldown: vi.fn(),
+    resetCooldown: vi.fn(),
+  }),
+}));
+
+import Menu from "../src/app/Menu";
+
+describe("Menu buttons", () => {
+  it("renders all expected menu buttons", () => {
+    render(<Menu />);
+
+    expect(
+      screen.getByRole("button", { name: /play vs player/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /play vs computer/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /live match/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /tutorial/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign in|sign out/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /adjust sound/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /keyboard shortcuts/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,17 @@
 /// <reference types="vitest" />
-
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"), // Resolve "@/..." to src/
+    },
+  },
   test: {
-    globals: true,        // allows Jest-like `describe`, `it`, `expect`
-    environment: "jsdom", // simulate browser for React
-    setupFiles: "./vitest.setup.ts", // like jest.setup.js
+    globals: true,        
+    environment: "jsdom", 
+    setupFiles: "./vitest.setup.ts",
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom";
+import React from "react";
+
+// Make React globally available in tests
+(globalThis as any).React = React;


### PR DESCRIPTION
This PR adds a minimal unit test for the `Menu` page using Vitest and React Testing Library. It verifies that all expected menu buttons (`Play vs Player`, `Play vs Computer`, `Live Match`, `Tutorial`, `Sign In/Sign Out`, `Adjust Sound`, `Keyboard Shortcuts`) render correctly.

The change ensures UI consistency and helps prevent accidental removal or renaming of menu buttons in future updates.

Fixes issue #190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the Menu to verify key actions are present: Play vs player, Play vs computer, Live match, Tutorial, Sign in/Sign out, Adjust sound, and Keyboard shortcuts. Improves confidence in core navigation and settings.
* **Chores**
  * Improved test setup by adding a source path alias for cleaner imports.
  * Exposed React globally in the test environment to simplify test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->