### PR TITLE
Add unit test for Menu page header rendering (#189)

### DIFF
--- a/__tests__/menuHeader.test.tsx
+++ b/__tests__/menuHeader.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import Menu from "../src/app/Menu"; 
+
+// Mock dependencies used in Menu
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/services/firebase", () => ({
+  signInWithGoogle: vi.fn(),
+  signOutUser: vi.fn(),
+}));
+
+vi.mock("@/services/store", () => ({
+  useUser: (selector: any) => selector({ user: null, setUser: vi.fn() }),
+  useTut: (selector: any) => selector({ setShowTut: vi.fn() }),
+  useSound: () => ({
+    bgMute: false,
+    bgVolume: 0.5,
+    setBgMute: vi.fn(),
+    setBgVolume: vi.fn(),
+    sfxMute: false,
+    sfxVolume: 0.5,
+    setSfxMute: vi.fn(),
+    setSfxVolume: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/hooks/useToastCooldown", () => ({
+  useToastCooldown: () => ({
+    canShowToast: () => true,
+    triggerToastCooldown: vi.fn(),
+    resetCooldown: vi.fn(),
+  }),
+}));
+
+describe("Menu Header", () => {
+  it("renders the menu page header correctly", () => {
+    render(<Menu />);
+    expect(screen.getByText(/Notakto/i)).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,18 +1,17 @@
 /// <reference types="vitest" />
-
 import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src"), 
+      "@": path.resolve(__dirname, "src"), // Resolve "@/..." to src/
     },
   },
   test: {
-    globals: true,      
-    environment: "jsdom", 
-    setupFiles: "./vitest.setup.ts", 
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,18 @@
 /// <reference types="vitest" />
 
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"), 
+    },
+  },
   test: {
-    globals: true,        // allows Jest-like `describe`, `it`, `expect`
-    environment: "jsdom", // simulate browser for React
-    setupFiles: "./vitest.setup.ts", // like jest.setup.js
+    globals: true,      
+    environment: "jsdom", 
+    setupFiles: "./vitest.setup.ts", 
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,4 @@
 import "@testing-library/jest-dom";
+import React from "react";
+
+;(globalThis as any).React = React;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
 import React from "react";
 
-;(globalThis as any).React = React;
+// Make React globally available in tests
+(globalThis as any).React = React;


### PR DESCRIPTION
This PR adds a minimal unit test for the Menu page header using Vitest and React Testing Library. It verifies that the header text ("Notakto") renders correctly on the Menu page.

Ensures UI consistency and prevents accidental removal or modification of the Menu page header in future updates. Improves confidence that the core navigation UI is rendered correctly.

- Added `__tests__/menuHeader.test.tsx` to test Menu page header rendering.
- Ensured test environment has React globally available and uses jsdom.

Fixes issue #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added automated test to verify the menu header displays the app title, improving reliability and preventing regressions.
- Chores
  - Applied minor formatting updates to the test configuration with no impact on functionality or user experience.

No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->