### PR TITLE
Refactor WinnerModal

### DIFF
--- a/src/components/ui/Containers/WinnerModal/WinnerAction.tsx
+++ b/src/components/ui/Containers/WinnerModal/WinnerAction.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+
+interface WinnerActionProps {
+    children: ReactNode;
+}
+
+export default function WinnerAction({ children }: WinnerActionProps) {
+    return (
+        <div className="flex justify-between gap-4 w-full">
+            {children}
+        </div>
+
+    );
+}

--- a/src/components/ui/Containers/WinnerModal/WinnerContainer.tsx
+++ b/src/components/ui/Containers/WinnerModal/WinnerContainer.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+
+interface WinnerContainerProps {
+    children: ReactNode;
+}
+
+export default function WinnerContainer({ children }: WinnerContainerProps) {
+    return (
+        <div className="bg-black text-center rounded-xl p-6 w-[80%] max-w-md shadow-2xl">
+            {children}
+        </div>
+
+    );
+}

--- a/src/components/ui/Title/WinnerMessage.tsx
+++ b/src/components/ui/Title/WinnerMessage.tsx
@@ -1,0 +1,7 @@
+
+const WinnerMessage = ({ text }: { text: string }) => (
+  <p className="text-2xl text-red-500 mb-6">
+    {text}
+  </p>
+);
+export default WinnerMessage

--- a/src/components/ui/Title/WinnerTitle.tsx
+++ b/src/components/ui/Title/WinnerTitle.tsx
@@ -1,0 +1,7 @@
+
+const WinnerTitle = ({ text }: { text: string }) => (
+  <h2 className="text-5xl text-red-600 mb-3">
+    {text}
+  </h2>
+);
+export default WinnerTitle

--- a/src/modals/WinnerModal.tsx
+++ b/src/modals/WinnerModal.tsx
@@ -1,6 +1,11 @@
 import { useRouter } from "next/navigation";
 import { WinnerModalProps } from "@/services/types";
 import { WinnerButton } from "@/components/ui/Buttons/WinnerButton";
+import ModalOverlay from "@/components/ui/Overlays/ModalOverlay";
+import WinnerContainer from "@/components/ui/Containers/WinnerModal/WinnerContainer";
+import WinnerAction from "@/components/ui/Containers/WinnerModal/WinnerAction";
+import WinnerTitle from "@/components/ui/Title/WinnerTitle";
+import WinnerMessage from "@/components/ui/Title/WinnerMessage";
 
 const WinnerModal = ({ visible, winner, onPlayAgain }: WinnerModalProps) => {
   if (!visible) return null;
@@ -9,23 +14,18 @@ const WinnerModal = ({ visible, winner, onPlayAgain }: WinnerModalProps) => {
     router.push('/');
   }
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-      <div className="bg-black text-center rounded-xl p-6 w-[80%] max-w-md shadow-2xl">
-        <h1 className="text-5xl text-red-600 mb-3">Game Over!</h1>
-        <p className="text-2xl text-red-500 mb-6">
-          {winner === 'You' ? 'You won!' : `${winner} wins`}
-        </p>
+    <ModalOverlay>
+      <WinnerContainer>
+        <WinnerTitle text="Game Over!" />
+        <WinnerMessage text={winner === 'You' ? 'You won!' : `${winner} wins`} />
 
-        <div className="flex justify-between gap-4 w-full">
-          <WinnerButton onClick={onPlayAgain}>
-            Play Again
-          </WinnerButton>
-          <WinnerButton onClick={exitToMenu}>
-            Main Menu
-          </WinnerButton>
-        </div>
-      </div>
-    </div>
+        <WinnerAction>
+          <WinnerButton onClick={onPlayAgain}>Play Again</WinnerButton>
+          <WinnerButton onClick={exitToMenu}>Main Menu</WinnerButton>
+        </WinnerAction>
+
+      </WinnerContainer>
+    </ModalOverlay>
   );
 };
 


### PR DESCRIPTION
### Description
- The current codebase uses inline Tailwind utility classes directly within the JSX (e.g., className="bg-blue-600 py-4 text-white text-[30px]").

### This results in:

- Visual bloat in the component files
- Repetition across files (Settings, Reset, Main Menu buttons, etc.)
- Difficulty maintaining consistent design
- Doesnt Follow the Princpiles of DRY

This Issue is for `WinnerModal.tsx` and will add components to reduce tailwind classes

closes #234 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the Game Over modal with clearer title and message, improved spacing and contrast, and a more responsive layout for better readability.
* **Refactor**
  * Rebuilt the Game Over modal using reusable UI components for title, message, container, and actions, improving consistency and maintainability without changing behavior or available actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->