### PR TITLE
[FEAT] Added Keyboard Shortcuts

### DIFF
--- a/src/app/Menu.tsx
+++ b/src/app/Menu.tsx
@@ -2,32 +2,41 @@
 
 import { useRouter } from 'next/navigation';
 import { signInWithGoogle, signOutUser } from '@/services/firebase';
-import { useUser, useTut } from '@/services/store';
+import { useUser } from '@/services/store';
 import { toast } from "react-toastify";
 import { useToastCooldown } from "@/components/hooks/useToastCooldown";
-import { TOAST_DURATION,TOAST_IDS } from "@/constants/toast";
+import { TOAST_DURATION, TOAST_IDS } from "@/constants/toast";
 import { MenuButton } from '@/components/ui/Buttons/MenuButton';
 import MenuContainer from '@/components/ui/Containers/Menu/MenuContainer';
 import MenuButtonContainer from '@/components/ui/Containers/Menu/MenuButtonContainer';
 import { MenuTitle } from '@/components/ui/Title/MenuTitle';
 import SoundConfigModal from '@/modals/SoundConfigModal';
 import ShortcutModal from '@/modals/ShortcutModal';
+import { useShortcut } from '@/components/hooks/useShortcut';
+import TutorialModal from '@/modals/TutorialModal';
 import { useState } from 'react';
+
+type ModalType = 'soundConfig' | 'shortcut' | 'tutorial' | null;
 
 const Menu = () => {
   const user = useUser((state) => state.user);
   const setUser = useUser((state) => state.setUser);
-  const setShowTut = useTut((state) => state.setShowTut);
 
   const router = useRouter();
   const { canShowToast, triggerToastCooldown, resetCooldown } = useToastCooldown(TOAST_DURATION);
-  const [showSoundConfig, setShowSoundConfig] = useState<boolean>(false);
-  const [showShortcutConfig, setshowShortcutConfig] = useState<boolean>(false);
+  const [activeModal, setActiveModal] = useState<ModalType>(null);
+
+  useShortcut({
+    escape: () => setActiveModal(null),
+    s: () => setActiveModal(prev => prev === 'soundConfig' ? null : 'soundConfig'),
+    q: () => setActiveModal(prev => prev === 'shortcut' ? null : 'shortcut'),
+    t: () => setActiveModal(prev => prev === 'tutorial' ? null : 'tutorial'),
+  });
 
   const handleSignIn = async () => {
     try {
       await signInWithGoogle();
-      toast.dismiss(TOAST_IDS.User.SignInError); 
+      toast.dismiss(TOAST_IDS.User.SignInError);
       resetCooldown();
     } catch (error) {
       console.error('Sign in error:', error);
@@ -64,13 +73,14 @@ const Menu = () => {
         <MenuButton onClick={() => startGame('vsPlayer')}> Play vs Player </MenuButton>
         <MenuButton onClick={() => startGame('vsComputer')}> Play vs Computer </MenuButton>
         <MenuButton onClick={() => startGame('liveMatch')}> Live Match </MenuButton>
-        <MenuButton onClick={() => setShowTut(true)}> Tutorial </MenuButton>
-        <MenuButton onClick={(user) ? handleSignOut : handleSignIn}>{(user) ? "Sign Out" : "Sign in"}</MenuButton>
-        <MenuButton onClick={() => setShowSoundConfig(!showSoundConfig)}>Adjust Sound</MenuButton>
-        <MenuButton onClick={() => setshowShortcutConfig(!showShortcutConfig)}>Keyboard Shortcuts</MenuButton>
+        <MenuButton onClick={() => setActiveModal('tutorial')}> Tutorial </MenuButton>
+        <MenuButton onClick={user ? handleSignOut : handleSignIn}>{user ? "Sign Out" : "Sign in"}</MenuButton>
+        <MenuButton onClick={() => setActiveModal('soundConfig')}>Adjust Sound</MenuButton>
+        <MenuButton onClick={() => setActiveModal('shortcut')}>Keyboard Shortcuts</MenuButton>
       </MenuButtonContainer >
-      <SoundConfigModal visible={showSoundConfig} onClose={() => setShowSoundConfig(false)} />
-      <ShortcutModal visible={showShortcutConfig} onClose={() => setshowShortcutConfig(false)} />
+      <SoundConfigModal visible={activeModal === 'soundConfig'} onClose={() => setActiveModal(null)} />
+      <ShortcutModal visible={activeModal === 'shortcut'} onClose={() => setActiveModal(null)} />
+      <TutorialModal visible={activeModal === 'tutorial'} onClose={() => setActiveModal(null)} />
     </MenuContainer >
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,12 @@
 'use client'
 import Menu from '@/app/Menu';
-import TutorialModal from '@/modals/TutorialModal';
-
-import { useTut } from '@/services/store';
-
 import { MenuLayout } from '@/components/ui/Containers/Menu/MenuLayout';
-import { useEffect } from 'react';
-
 
 export default function Home() {
-  const showTut = useTut((state): boolean => state.showTut);
 
   return (
     <MenuLayout>
       <Menu />
-      {showTut && <TutorialModal />}
     </MenuLayout>
   );
 }

--- a/src/components/hooks/useShortcut.ts
+++ b/src/components/hooks/useShortcut.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type ShortcutHandler = (event: KeyboardEvent) => void;
+type ShortcutMap = Record<string, ShortcutHandler>;
+
+export function useShortcut(shortcuts: ShortcutMap) {
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const el = e.target as HTMLElement | null;
+            const tag = el?.tagName?.toLowerCase();
+
+            if (e.isComposing || e.repeat || e.ctrlKey || e.metaKey || e.altKey) return;
+            if (tag === 'input' || tag === 'textarea' || el?.isContentEditable) return;
+
+            const key = e.key.toLowerCase();
+            if (shortcuts[key]) {
+                e.preventDefault();
+                shortcuts[key](e);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [shortcuts]);
+}

--- a/src/components/ui/Buttons/TutorialButton.tsx
+++ b/src/components/ui/Buttons/TutorialButton.tsx
@@ -7,7 +7,7 @@ export function TutorialButton({
         <button
             {...props}
             className={
-                "bg-red-600 text-white text-xl px-6 py-3 rounded text-center w-full"
+                "bg-red-600 text-white text-xl px-6 py-3 text-center w-full"
             }
         />
     );

--- a/src/modals/PlayerNamesModal.tsx
+++ b/src/modals/PlayerNamesModal.tsx
@@ -36,7 +36,7 @@ const PlayerNamesModal = ({ visible, onSubmit, initialNames = ['Player 1', 'Play
     }
     toast.dismiss(TOAST_IDS.PlayerNames.Duplicate);
     resetCooldown();
-    
+
     onSubmit(player1 || 'Player 1', player2 || 'Player 2');
   };
 

--- a/src/modals/ShortcutModal.tsx
+++ b/src/modals/ShortcutModal.tsx
@@ -20,21 +20,17 @@ export default function ShortcutModal({ visible, onClose }: ShortcutModalProps) 
         { key: 'N', action: 'Reset player names' },
         { key: 'C', action: 'Open game configuration' },
         { key: 'M', action: 'Go to main menu' },
+        { key: 'D', action: 'Open difficulty level' },
         { key: 'S', action: 'Adjust sound' },
-        { key: 'Enter', action: 'Return to game' },
+        { key: 'Q', action: 'Open keyboard shortcuts' },
+        { key: 'T', action: 'Open tutorial' },
     ];
 
     return (
         <ModalOverlay>
             <ShortcutContainer>
                 <ShortcutTitle text="Keyboard Shortcuts" />
-
-                {/* Pending notice */}
-                <div className="bg-yellow-500/20 border border-yellow-500 text-yellow-400 p-3 rounded-lg text-md">
-                    ⚠️ NOTE : These shortcuts are for reference only. Implementation is pending, so they
-                    won’t work right now.
-                </div>
-
+                
                 <ShortcutList shortcuts={shortcuts} />
 
                 <ShortcutButton onClick={onClose}>Return</ShortcutButton>

--- a/src/modals/TutorialModal.tsx
+++ b/src/modals/TutorialModal.tsx
@@ -3,12 +3,14 @@ import TutorialContainer from "@/components/ui/Containers/Tutorial/TutorialConta
 import ModalOverlay from "@/components/ui/Overlays/ModalOverlay";
 import TutorialTitle from "@/components/ui/Title/TutorialTitle";
 import TutorialList from "@/components/ui/List/TutorialList";
-import { useTut } from "@/services/store";
 
-const TutorialModal = () => {
-  const { showTut, setShowTut } = useTut();
-  if (!showTut) return null;
+interface TutorialProps {
+  visible: boolean;
+  onClose: () => void;
+}
 
+const TutorialModal = ({ visible, onClose }: TutorialProps) => {
+  if (!visible) return null;
   const rules = [
     "Both players use X marks",
     "Game is played on three 3x3 boards",
@@ -26,7 +28,7 @@ const TutorialModal = () => {
         <TutorialList items={rules} />
 
         <TutorialButton
-          onClick={() => setShowTut(false)}
+          onClick={onClose}
         >
           Close&nbsp;&nbsp;&nbsp;Tutorial
         </TutorialButton>

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -55,10 +55,6 @@ export const useUser = create<userStore>((set) => ({
   setUser: (newUser) => set({ user: newUser }),
 }));
 
-export const useTut = create<tutStore>((set) => ({
-  showTut: false,
-  setShowTut: (newShowTut) => set({ showTut: newShowTut }),
-}));
 export const useCoins = create<CoinStore>((set, get) => ({
   coins: 0,
   setCoins: (newCoins: number) => set({ coins: newCoins }),

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -150,3 +150,7 @@ export interface AnimatedTitleProps {
   // Optional class for inner text element (color/size overrides)
   textClassName?: string;
 }
+
+export type PlayerButtonModalType = 'names' | 'winner' | 'boardConfig' | 'soundConfig' | 'shortcut' | null;
+
+export type ComputerButtonModalType = 'winner' | 'boardConfig' | 'soundConfig' | 'difficulty' | 'shortcut' | null;


### PR DESCRIPTION
### Description

- Add keyboard shortcuts for common actions in the game.

### Tasks

-  Define default shortcut keys (e.g., Esc = Close modal, R = Reset, M = Main Menu, etc.).
-  Ensure shortcuts trigger the correct actions in the game.

closes #148 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Tutorial modal, accessible from the menu and via T.
  - Introduced keyboard shortcuts: Esc (close), S (Sound), Q (Shortcuts), D (Difficulty, vs Computer). Streamlined modal behavior across screens.
  - Updated in-app Shortcuts help to include new keys.

- Changes
  - Removed the Enter → Return to game shortcut.

- Style
  - Tutorial button no longer rounded for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->