### PR TITLE
Optimized toast cooldown logic 

### DIFF
--- a/src/components/hooks/useToastCooldown.ts
+++ b/src/components/hooks/useToastCooldown.ts
@@ -13,11 +13,10 @@ export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 		if (cooldownTimer.current) {
 			clearTimeout(cooldownTimer.current);
 		}
-		const resetTime = Math.max(0, cooldown - 50);
 		cooldownTimer.current = setTimeout(() => {
 			isOnCooldown.current = false;
 			cooldownTimer.current = null;
-		}, resetTime);
+		}, cooldown);
 	}, [cooldown]);
 
 	const resetCooldown = useCallback(() => {

--- a/src/components/hooks/useToastCooldown.ts
+++ b/src/components/hooks/useToastCooldown.ts
@@ -1,8 +1,6 @@
 import { useCallback, useRef } from "react";
 import { TOAST_DURATION } from "@/constants/toast";
 
-const EARLY_RESET_MS = 400;
-
 export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 	const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const isOnCooldown = useRef(false);
@@ -10,18 +8,17 @@ export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 	const canShowToast = useCallback(() => !isOnCooldown.current, []);
 
 	const triggerToastCooldown = useCallback(() => {
-		isOnCooldown.current = true;
+		isOnCooldown.current = false;
 
 		if (cooldownTimer.current) {
 			clearTimeout(cooldownTimer.current);
 		}
-
+        const resetTime = Math.max(0, cooldown - 1000); 
 		cooldownTimer.current = setTimeout(
 			() => {
 				isOnCooldown.current = false;
 				cooldownTimer.current = null;
-			},
-			Math.max(0, cooldown - EARLY_RESET_MS),
+			},resetTime
 		);
 	}, [cooldown]);
 

--- a/src/components/hooks/useToastCooldown.ts
+++ b/src/components/hooks/useToastCooldown.ts
@@ -8,12 +8,12 @@ export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 	const canShowToast = useCallback(() => !isOnCooldown.current, []);
 
 	const triggerToastCooldown = useCallback(() => {
-		isOnCooldown.current = false;
+		isOnCooldown.current = true;
 
 		if (cooldownTimer.current) {
 			clearTimeout(cooldownTimer.current);
 		}
-		const resetTime = Math.max(0, cooldown - 1000);
+		const resetTime = Math.max(0, cooldown - 50);
 		cooldownTimer.current = setTimeout(() => {
 			isOnCooldown.current = false;
 			cooldownTimer.current = null;

--- a/src/components/hooks/useToastCooldown.ts
+++ b/src/components/hooks/useToastCooldown.ts
@@ -13,13 +13,11 @@ export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 		if (cooldownTimer.current) {
 			clearTimeout(cooldownTimer.current);
 		}
-        const resetTime = Math.max(0, cooldown - 1000); 
-		cooldownTimer.current = setTimeout(
-			() => {
-				isOnCooldown.current = false;
-				cooldownTimer.current = null;
-			},resetTime
-		);
+		const resetTime = Math.max(0, cooldown - 1000);
+		cooldownTimer.current = setTimeout(() => {
+			isOnCooldown.current = false;
+			cooldownTimer.current = null;
+		}, resetTime);
 	}, [cooldown]);
 
 	const resetCooldown = useCallback(() => {

--- a/src/components/hooks/useToastCooldown.ts
+++ b/src/components/hooks/useToastCooldown.ts
@@ -11,13 +11,16 @@ export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 		isOnCooldown.current = true;
 
 		if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+		const earlyReset = 400;
 		cooldownTimer.current = setTimeout(() => {
 			isOnCooldown.current = false;
-		}, cooldown);
+			cooldownTimer.current = null;
+		}, Math.max(0, cooldown - earlyReset));
 	}, [cooldown]);
 
 	const resetCooldown = useCallback(() => {
 		if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+		cooldownTimer.current = null;
 		isOnCooldown.current = false;
 	}, []);
 

--- a/src/components/hooks/useToastCooldown.ts
+++ b/src/components/hooks/useToastCooldown.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef } from "react";
 import { TOAST_DURATION } from "@/constants/toast";
 
+const EARLY_RESET_MS = 400;
+
 export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 	const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const isOnCooldown = useRef(false);
@@ -10,16 +12,23 @@ export function useToastCooldown(cooldown: number = TOAST_DURATION) {
 	const triggerToastCooldown = useCallback(() => {
 		isOnCooldown.current = true;
 
-		if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
-		const earlyReset = 400;
-		cooldownTimer.current = setTimeout(() => {
-			isOnCooldown.current = false;
-			cooldownTimer.current = null;
-		}, Math.max(0, cooldown - earlyReset));
+		if (cooldownTimer.current) {
+			clearTimeout(cooldownTimer.current);
+		}
+
+		cooldownTimer.current = setTimeout(
+			() => {
+				isOnCooldown.current = false;
+				cooldownTimer.current = null;
+			},
+			Math.max(0, cooldown - EARLY_RESET_MS),
+		);
 	}, [cooldown]);
 
 	const resetCooldown = useCallback(() => {
-		if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+		if (cooldownTimer.current) {
+			clearTimeout(cooldownTimer.current);
+		}
 		cooldownTimer.current = null;
 		isOnCooldown.current = false;
 	}, []);


### PR DESCRIPTION
This PR refines the useToastCooldown hook to ensure faster re-triggering of toasts after the cooldown ends.
It doesn’t modify React-Toastify’s internal animation delays but removes any unnecessary delay caused by the cooldown logic itself.
Changes made:
Added a small early reset (cooldown - 50ms) to make cooldown end slightly earlier.
Ensured cooldown cleanup and reset logic works reliably.
Prevents duplicate toasts without introducing visual delay.
Note:
Any remaining short delay is due to React-Toastify’s animation and rendering, which is outside this hook’s control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timer management and cleanup logic for notification cooldown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->