### PR TITLE
changed tutorial ui

### DIFF
--- a/src/components/ui/Buttons/TutorialButton.tsx
+++ b/src/components/ui/Buttons/TutorialButton.tsx
@@ -7,7 +7,7 @@ export function TutorialButton({
 		<button
 			{...props}
 			className={
-				"bg-red-600 text-white text-xl px-6 py-3 rounded text-center w-full"
+				"bg-red-600 text-white text-2xl px-6 py-3 rounded text-center w-full"
 			}
 		/>
 	);

--- a/src/components/ui/Title/TutorialTitle.tsx
+++ b/src/components/ui/Title/TutorialTitle.tsx
@@ -1,4 +1,4 @@
 const TutorialTitle = ({ text }: { text: string }) => (
-	<h2 className="text-3xl text-red-600 text-center mb-4">{text}</h2>
+	<h2 className="text-4xl text-red-600 text-center mb-4">{text}</h2>
 );
 export default TutorialTitle;

--- a/src/modals/TutorialModal.tsx
+++ b/src/modals/TutorialModal.tsx
@@ -21,12 +21,12 @@ const TutorialModal = () => {
 	return (
 		<ModalOverlay>
 			<TutorialContainer>
-				<TutorialTitle text="How&nbsp;&nbsp;&nbsp;to&nbsp;&nbsp;&nbsp;Play Notakto" />
+				<TutorialTitle text="How&nbsp;to&nbsp;Play&nbsp;Notakto" />
 
 				<TutorialList items={rules} />
 
 				<TutorialButton onClick={() => setShowTut(false)}>
-					Close&nbsp;&nbsp;&nbsp;Tutorial
+					Close&nbsp;Tutorial
 				</TutorialButton>
 			</TutorialContainer>
 		</ModalOverlay>


### PR DESCRIPTION
## Description
There is too much space between the heading ("How to Play Notakto") and the bottom buttons ("Close Tutorial").
This makes the modal look unbalanced.

### Purpose of this PR:
Issue: Excessive spacing between words in tutorial modal


### Related Issue
Closes #224.

## Category (replace the empty space inside brackets with x for tick)
- [ ] Bug
- [ ] Refactor
- [x] Enhancement/New Feature
- [ ] Tests
- [ ] Documentation

## Checklist 
- [x] I have read and reviewed each line of my Git/File Differences for this PR very carefully and I clearly understand the reason behind the code changes and decisions I have made
- [x] This PR is short and cant be decomposed further without breaking consistency (check ../docs/SHORT_PR.md for more information)
- [x] I have manually tested all the changes and indirect impacts these changes could have made
- [x] I have added/updated automated testing scripts (check ../docs/TESTS_FOR_PR.md for more information)
- [x] I will keep my branch updated with main till this branch doesn't get merged
- [ ] Documentations updated if applicable
- [ ] Code reviewed for accessibility
- [x] I will check the review made by coderabbit (both actionable and nitpick) and will respond with atleast a short comment of why I disagree with it
- [x] I understand maintainers might not be able to help with general doubts like git, tech stack etc
- [x] I will post the doubts regarding repository/project in Discussions tab only, so that fellow contributors could help me
- [x] I understand that doubts related to an issue or PR will be made as comment to the same.
- [x] I do not have any existing open PR pending to be merged
- [x] If I am making this PR as a part of any competition then I will name it and mention e-mail id registered with that competition

## Screenshots (if applicable)
Add images here.