### PR TITLE
Refine Shortcut Behavior Before Game Start and When Settings Are Open

### DIFF
--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -76,22 +76,28 @@ const Game = () => {
 	// const { canShowToast, resetCooldown } = useToastCooldown(TOAST_DURATION);
 	const router = useRouter();
 
-	useShortcut({
-		escape: () => {
-			if (activeModal) return setActiveModal(null);
-			return setIsMenuOpen(false);
+	useShortcut(
+		{
+			escape: () => {
+				if (activeModal) return setActiveModal(null);
+				return setIsMenuOpen(false);
+			},
+			m: () => router.push("/"),
+			r: () => handleReset(),
+			c: () =>
+				setActiveModal((prev) =>
+					prev === "boardConfig" ? null : "boardConfig",
+				),
+			s: () =>
+				setActiveModal((prev) =>
+					prev === "soundConfig" ? null : "soundConfig",
+				),
+			d: () =>
+				setActiveModal((prev) => (prev === "difficulty" ? null : "difficulty")),
+			q: () =>
+				setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut")),
 		},
-		m: () => router.push("/"),
-		r: () => handleReset(),
-		c: () =>
-			setActiveModal((prev) => (prev === "boardConfig" ? null : "boardConfig")),
-		s: () =>
-			setActiveModal((prev) => (prev === "soundConfig" ? null : "soundConfig")),
-		d: () =>
-			setActiveModal((prev) => (prev === "difficulty" ? null : "difficulty")),
-		q: () =>
-			setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut")),
-	},isMenuOpen // disabled condition
+		isMenuOpen, // disabled condition
 	);
 
 	const initGame = async (

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -91,7 +91,8 @@ const Game = () => {
 			setActiveModal((prev) => (prev === "difficulty" ? null : "difficulty")),
 		q: () =>
 			setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut")),
-	});
+	},isMenuOpen // disabled condition
+	);
 
 	const initGame = async (
 		num: BoardNumber,

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -54,6 +54,7 @@ const Game = () => {
 			return setIsMenuOpen(false);
 		},
 		m: () => {
+			if (!initialSetupDone) return;
 			router.push("/");
 		},
 		r: () => {
@@ -75,7 +76,8 @@ const Game = () => {
 			if (!initialSetupDone) return;
 			setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut"));
 		},
-	});
+	},isMenuOpen // disabled option
+	);
 
 	const makeMove = (boardIndex: number, cellIndex: number) => {
 		if (

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -59,7 +59,8 @@ const Game = () => {
 				router.push("/");
 			},
 			r: () => {
-				if (initialSetupDone) resetGame(numberOfBoards, boardSize);
+				if (!initialSetupDone) return;
+				resetGame(numberOfBoards, boardSize);
 			},
 			n: () => {
 				if (!initialSetupDone) return;

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -47,36 +47,42 @@ const Game = () => {
 	const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
 	const router = useRouter();
 
-	useShortcut({
-		escape: () => {
-			if (!initialSetupDone && !gameStarted) return;
-			if (activeModal) return setActiveModal(null);
-			return setIsMenuOpen(false);
+	useShortcut(
+		{
+			escape: () => {
+				if (!initialSetupDone && !gameStarted) return;
+				if (activeModal) return setActiveModal(null);
+				return setIsMenuOpen(false);
+			},
+			m: () => {
+				if (!initialSetupDone) return;
+				router.push("/");
+			},
+			r: () => {
+				if (initialSetupDone) resetGame(numberOfBoards, boardSize);
+			},
+			n: () => {
+				if (!initialSetupDone) return;
+				setActiveModal((prev) => (prev === "names" ? null : "names"));
+			},
+			c: () => {
+				if (!initialSetupDone) return;
+				setActiveModal((prev) =>
+					prev === "boardConfig" ? null : "boardConfig",
+				);
+			},
+			s: () => {
+				if (!initialSetupDone) return;
+				setActiveModal((prev) =>
+					prev === "soundConfig" ? null : "soundConfig",
+				);
+			},
+			q: () => {
+				if (!initialSetupDone) return;
+				setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut"));
+			},
 		},
-		m: () => {
-			if (!initialSetupDone) return;
-			router.push("/");
-		},
-		r: () => {
-			if (initialSetupDone) resetGame(numberOfBoards, boardSize);
-		},
-		n: () => {
-			if (!initialSetupDone) return;
-			setActiveModal((prev) => (prev === "names" ? null : "names"));
-		},
-		c: () => {
-			if (!initialSetupDone) return;
-			setActiveModal((prev) => (prev === "boardConfig" ? null : "boardConfig"));
-		},
-		s: () => {
-			if (!initialSetupDone) return;
-			setActiveModal((prev) => (prev === "soundConfig" ? null : "soundConfig"));
-		},
-		q: () => {
-			if (!initialSetupDone) return;
-			setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut"));
-		},
-	},isMenuOpen // disabled option
+		isMenuOpen, // disabled option
 	);
 
 	const makeMove = (boardIndex: number, cellIndex: number) => {

--- a/src/components/hooks/useShortcut.ts
+++ b/src/components/hooks/useShortcut.ts
@@ -5,26 +5,28 @@ import { useEffect } from "react";
 type ShortcutHandler = (event: KeyboardEvent) => void;
 type ShortcutMap = Record<string, ShortcutHandler>;
 
-export function useShortcut(shortcuts: ShortcutMap) {
+export function useShortcut(shortcuts: ShortcutMap , disabled : boolean = false) {
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
+			const key = e.key.toLowerCase();
+			if (disabled && key !== "escape") return;
+
 			const el = e.target as HTMLElement | null;
 			const tag = el?.tagName?.toLowerCase();
-
+			
 			// ignore if composing, holding modifiers, or typing in an input
 			if (e.isComposing || e.repeat || e.ctrlKey || e.metaKey || e.altKey)
 				return;
 			if (tag === "input" || tag === "textarea" || el?.isContentEditable)
 				return;
-
-			const key = e.key.toLowerCase();
+			
 			if (shortcuts[key]) {
-				e.preventDefault(); // optional
+				e.preventDefault();
 				shortcuts[key](e);
 			}
 		};
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [shortcuts]);
+	}, [shortcuts , disabled]);
 }

--- a/src/components/hooks/useShortcut.ts
+++ b/src/components/hooks/useShortcut.ts
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 type ShortcutHandler = (event: KeyboardEvent) => void;
 type ShortcutMap = Record<string, ShortcutHandler>;
 
-export function useShortcut(shortcuts: ShortcutMap , disabled : boolean = false) {
+export function useShortcut(shortcuts: ShortcutMap, disabled: boolean = false) {
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			const key = e.key.toLowerCase();
@@ -13,13 +13,13 @@ export function useShortcut(shortcuts: ShortcutMap , disabled : boolean = false)
 
 			const el = e.target as HTMLElement | null;
 			const tag = el?.tagName?.toLowerCase();
-			
+
 			// ignore if composing, holding modifiers, or typing in an input
 			if (e.isComposing || e.repeat || e.ctrlKey || e.metaKey || e.altKey)
 				return;
 			if (tag === "input" || tag === "textarea" || el?.isContentEditable)
 				return;
-			
+
 			if (shortcuts[key]) {
 				e.preventDefault();
 				shortcuts[key](e);
@@ -28,5 +28,5 @@ export function useShortcut(shortcuts: ShortcutMap , disabled : boolean = false)
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [shortcuts , disabled]);
+	}, [shortcuts, disabled]);
 }


### PR DESCRIPTION
## Description

### Purpose of this PR:

### How to test this PR manually:

### Related Issue
Closes #308 

## Category (replace the empty space inside brackets with x for tick)
- [x] Bug
- [ ] Refactor
- [x] Enhancement/New Feature
- [ ] Tests
- [ ] Documentation

## Checklist 
- [x] I have read and reviewed each line of my Git/File Differences for this PR very carefully and I clearly understand the reason behind the code changes and decisions I have made
- [x] This PR is short and cant be decomposed further without breaking consistency (check ../docs/SHORT_PR.md for more information)
- [ ] I have manually tested all the changes and indirect impacts these changes could have made
- [ ] I have added/updated automated testing scripts (check ../docs/TESTS_FOR_PR.md for more information)
- [x] I will keep my branch updated with main till this branch doesn't get merged
- [ ] Documentations updated if applicable
- [] Code reviewed for accessibility
- [x] I will check the review made by coderabbit (both actionable and nitpick) and will respond with atleast a short comment of why I disagree with it
- [x] I understand maintainers might not be able to help with general doubts like git, tech stack etc
- [x] I will post the doubts regarding repository/project in Discussions tab only, so that fellow contributors could help me
- [x] I understand that doubts related to an issue or PR will be made as comment to the same.
- [x] I do not have any existing open PR pending to be merged
- [x] If I am making this PR as a part of any competition then I will name it and mention e-mail id registered with that competition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated keyboard shortcuts for gameplay and UI: navigate home (M), reset (R), toggle modals (N, C, S, D, Q), with Escape preserving existing close behaviors.
  * Shortcuts are automatically disabled while the main menu is open to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->