### PR TITLE
Fixed slider ambiguity

### DIFF
--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -5,10 +5,10 @@ export function SoundMuteButton({
 }: ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (
 		<button
-			className={
-				"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-20 text-lg"
-			}
 			{...props}
+			className={
+				"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-17 text-lg"
+			}
 		/>
 	);
 }

--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -5,7 +5,7 @@ export function SoundMuteButton({
 }: ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (
 		<button
-			className={"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 text-lg"}
+			className={"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-20 text-lg"}
 			{...props}
 		/>
 	);

--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -7,7 +7,7 @@ export function SoundMuteButton({
 		<button
 			{...props}
 			className={
-				"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-17 text-lg"
+				"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-[67px] text-lg"
 			}
 		/>
 	);

--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -5,7 +5,9 @@ export function SoundMuteButton({
 }: ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (
 		<button
-			className={"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-20 text-lg"}
+			className={
+				"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-20 text-lg"
+			}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
## Description
This pr resolves the ambiguity in sound modal
### Purpose of this PR:
Slider size changes when toggling between "Mute" and "Unmute" in audio settings, causing visual inconsistency. Ambiguity exists on whether slider position persists or resets on toggle.

### How to test this PR manually:
Go to the website and redirect urself to the sound configuration and toggle between mute and unmute were u get to see that the buttons don't change shape pushing the slider away or into the button ..this i the offered fix ....also note that it is the similar sound config model is being rendered in several other places like vsComputer and vsPlayer where u can go to setting and then navigate to sound config and ensure u see the same functionality
### Related Issue
Closes #280 
## Category (replace the empty space inside brackets with x for tick)
- [ ] Bug
- [ ] Refactor
- [x] Enhancement/New Feature
- [ ] Tests
- [ ] Documentation

## Checklist 
- [x] I have read and reviewed each line of my Git/File Differences for this PR very carefully and I clearly understand the reason behind the code changes and decisions I have made
- [x] This PR is short and cant be decomposed further without breaking consistency (check ../docs/SHORT_PR.md for more information)
- [x] I have manually tested all the changes and indirect impacts these changes could have made
- [ ] I have added/updated automated testing scripts (check ../docs/TESTS_FOR_PR.md for more information)
- [x] I will keep my branch updated with main till this branch doesn't get merged
- [x] Documentations updated if applicable
- [ ] Code reviewed for accessibility
- [x] I will check the review made by coderabbit (both actionable and nitpick) and will respond with atleast a short comment of why I disagree with it
- [x] I understand maintainers might not be able to help with general doubts like git, tech stack etc
- [x] I will post the doubts regarding repository/project in Discussions tab only, so that fellow contributors could help me
- [x] I understand that doubts related to an issue or PR will be made as comment to the same.
- [ ] I do not have any existing open PR pending to be merged
- [x] If I am making this PR as a part of any competition then I will name it and mention e-mail id registered with that competition

I am making this pr as a part of GSSOC and hacktober fest and my registered mail id is :
GSSOC:[gnaneshreddy0911@gmail.com](mailto:gnaneshreddy0911@gmail.com)
hacktober fest:[gnaneshreddyy@gmail.com](mailto:gnaneshreddyy@gmail.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the sound mute button to use a fixed width for improved visual consistency and usability, preserving its existing appearance and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->