### PR TITLE
Make Sound Configuration UI mobile responsive

### DIFF
--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -6,9 +6,10 @@ export function SoundMuteButton({
 	return (
 		<button
 			{...props}
-			className={
-				"bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-[67px] text-lg"
-			}
+			className="
+				bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-[67px] text-lg
+				max-[407px]:w-[90px]
+			"
 		/>
 	);
 }

--- a/src/components/ui/Buttons/SoundMuteButton.tsx
+++ b/src/components/ui/Buttons/SoundMuteButton.tsx
@@ -6,10 +6,10 @@ export function SoundMuteButton({
 	return (
 		<button
 			{...props}
-			className="
+			className={`
 				bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 w-[67px] text-lg
-				max-[407px]:w-[90px]
-			"
+				max-[407px]:w-[60px] max-[407px]:text-base max-[407px]:py-1
+			`}
 		/>
 	);
 }

--- a/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
+++ b/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
@@ -7,9 +7,7 @@ export default function SoundConfigSection({
 		<div
 			className="
 				my-4 flex items-center justify-between
-				/* Mobile responsiveness */
-				max-[407px]:flex-col max-[407px]:items-start max-[407px]:gap-3
-			"
+				max-[407px]:flex-col max-[407px]:items-start max-[407px]:gap-y-2"
 		>
 			{children}
 		</div>

--- a/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
+++ b/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
@@ -4,11 +4,7 @@ export default function SoundConfigSection({
 	children,
 }: SoundConfigSectionProps) {
 	return (
-		<div
-			className="
-				my-4 flex items-center justify-between
-				max-[407px]:flex-col max-[407px]:items-start max-[407px]:gap-y-2"
-		>
+		<div className="my-4 flex items-center justify-between max-[407px]:flex-col max-[407px]:items-start max-[407px]:gap-y-2">
 			{children}
 		</div>
 	);

--- a/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
+++ b/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
@@ -8,8 +8,7 @@ export default function SoundConfigSection({
 			className={`
 				my-4 flex items-center justify-between gap-3
 				max-[407px]:items-center max-[407px]:justify-start max-[407px]:gap-2
-			`}
-		>
+			`}>
 			{children}
 		</div>
 	);

--- a/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
+++ b/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
@@ -4,6 +4,14 @@ export default function SoundConfigSection({
 	children,
 }: SoundConfigSectionProps) {
 	return (
-		<div className="my-4 flex items-center justify-between">{children}</div>
+		<div
+			className="
+				my-4 flex items-center justify-between
+				/* Mobile responsiveness */
+				max-[407px]:flex-col max-[407px]:items-start max-[407px]:gap-3
+			"
+		>
+			{children}
+		</div>
 	);
 }

--- a/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
+++ b/src/components/ui/Containers/SoundConfig/SoundConfigSection.tsx
@@ -4,7 +4,12 @@ export default function SoundConfigSection({
 	children,
 }: SoundConfigSectionProps) {
 	return (
-		<div className="my-4 flex items-center justify-between max-[407px]:flex-col max-[407px]:items-start max-[407px]:gap-y-2">
+		<div
+			className={`
+				my-4 flex items-center justify-between gap-3
+				max-[407px]:items-center max-[407px]:justify-start max-[407px]:gap-2
+			`}
+		>
 			{children}
 		</div>
 	);

--- a/src/components/ui/Inputs/SoundConfigSlider.tsx
+++ b/src/components/ui/Inputs/SoundConfigSlider.tsx
@@ -11,10 +11,10 @@ export function SoundConfigSlider({
 			type="range"
 			min="0"
 			max="100"
-			className="
+			className={`
 				flex-2 mx-2 accent-[#0055ff]
-				max-[407px]:w-[90%] max-[407px]:mx-0
-			"
+				max-[407px]:w-[60%] max-[407px]:mx-1
+			`}
 		/>
 	);
 }

--- a/src/components/ui/Inputs/SoundConfigSlider.tsx
+++ b/src/components/ui/Inputs/SoundConfigSlider.tsx
@@ -11,7 +11,10 @@ export function SoundConfigSlider({
 			type="range"
 			min="0"
 			max="100"
-			className={"flex-2 mx-2 accent-[#0055ff]"}
+			className="
+				flex-2 mx-2 accent-[#0055ff]
+				max-[407px]:w-[90%] max-[407px]:mx-0
+			"
 		/>
 	);
 }

--- a/src/components/ui/Title/SoundConfigLabel.tsx
+++ b/src/components/ui/Title/SoundConfigLabel.tsx
@@ -5,9 +5,7 @@ const SoundConfigLabel = ({ label, htmlFor }: SoundConfigLabelProps) => (
 		htmlFor={htmlFor}
 		className="
 			text-red-500 text-2xl flex-1 text-left
-			max-[407px]:text-[1.5rem]
-		"
-	>
+			max-[407px]:text-[1.5rem]">
 		{label}
 	</label>
 );

--- a/src/components/ui/Title/SoundConfigLabel.tsx
+++ b/src/components/ui/Title/SoundConfigLabel.tsx
@@ -1,7 +1,13 @@
 import type { SoundConfigLabelProps } from "@/services/types";
 
 const SoundConfigLabel = ({ label, htmlFor }: SoundConfigLabelProps) => (
-	<label htmlFor={htmlFor} className="text-red-500 text-2xl flex-1 text-left">
+	<label
+		htmlFor={htmlFor}
+		className="
+			text-red-500 text-2xl flex-1 text-left
+			max-[407px]:text-[1.5rem]
+		"
+	>
 		{label}
 	</label>
 );

--- a/src/components/ui/Title/TutorialTitle.tsx
+++ b/src/components/ui/Title/TutorialTitle.tsx
@@ -1,4 +1,10 @@
 const TutorialTitle = ({ text }: { text: string }) => (
-	<h2 className="text-4xl text-red-600 text-center mb-4">{text}</h2>
+	<h2
+		className="text-4xl text-red-600 text-center mb-4
+			max-[480px]:text-[1.9rem] max-[400px]:text-[1.7rem]"
+	>
+		{text}
+	</h2>
 );
+
 export default TutorialTitle;

--- a/src/components/ui/Title/TutorialTitle.tsx
+++ b/src/components/ui/Title/TutorialTitle.tsx
@@ -1,10 +1,4 @@
 const TutorialTitle = ({ text }: { text: string }) => (
-	<h2
-		className="text-4xl text-red-600 text-center mb-4
-			max-[480px]:text-[1.9rem] max-[400px]:text-[1.7rem]"
-	>
-		{text}
-	</h2>
+	<h2 className="text-4xl text-red-600 text-center mb-4">{text}</h2>
 );
-
 export default TutorialTitle;


### PR DESCRIPTION
## Description

### Purpose of this PR:
This PR improves the Sound Configuration modal UI to make it fully mobile responsive.
It ensures that labels, sliders, and buttons adjust neatly on small screens (≤ 407 px) while maintaining the existing desktop design and button styling


### How to test this PR manually:
Run the project locally.

Open the Sound Configuration Modal.
Resize the viewport to around 400–500 px width (or test on a mobile device).
Verify that:
 Each section stacks vertically.
 Labels, sliders, and buttons align correctly on the left.
 Buttons retain their desktop styling.
 “Reset Sounds” and “Return” buttons stay side by side.
 Desktop layout remains unchanged above ~407 px width.

### Related Issue
Closes #344 

## Category (replace the empty space inside brackets with x for tick)
- [ ] Bug
- [ ] Refactor
- [x] Enhancement/New Feature
- [ ] Tests
- [ ] Documentation

## Checklist 
- [x] I have read and reviewed each line of my Git/File Differences for this PR very carefully and I clearly understand the reason behind the code changes and decisions I have made
- [x] This PR is short and cant be decomposed further without breaking consistency (check ../docs/SHORT_PR.md for more information)
- [x] I have manually tested all the changes and indirect impacts these changes could have made
- [ ] I have added/updated automated testing scripts (check ../docs/TESTS_FOR_PR.md for more information)
- [x] I will keep my branch updated with main till this branch doesn't get merged
- [x] Documentations updated if applicable
- [x] Code reviewed for accessibility
- [x] I will check the review made by coderabbit (both actionable and nitpick) and will respond with atleast a short comment of why I disagree with it
- [x] I understand maintainers might not be able to help with general doubts like git, tech stack etc
- [x] I will post the doubts regarding repository/project in Discussions tab only, so that fellow contributors could help me
- [x] I understand that doubts related to an issue or PR will be made as comment to the same.
- [x] I do not have any existing open PR pending to be merged
- [ ] If I am making this PR as a part of any competition then I will name it and mention e-mail id registered with that competition



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for sound configuration components on smaller viewports, with optimized spacing, text sizing, and button dimensions for enhanced mobile display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->