### PR TITLE
[FEATURE] : Added confirmation modal before r and m shortcut

### DIFF
--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -206,7 +206,6 @@ const Game = () => {
 	};
 
 	const handleReset = async () => {
-		
 		if (isResetting) return;
 		setIsResetting(true);
 

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -206,7 +206,7 @@ const Game = () => {
 	};
 
 	const handleReset = async () => {
-		setHasMoveHappened(false);
+		
 		if (isResetting) return;
 		setIsResetting(true);
 
@@ -214,6 +214,7 @@ const Game = () => {
 			if (user) {
 				const data = await resetGame(sessionId, await user.getIdToken());
 				if (data.success) {
+					setHasMoveHappened(false);
 					setBoards(data.gameState.boards);
 					setCurrentPlayer(data.gameState.currentPlayer);
 					setGameHistory(data.gameState.gameHistory);

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -77,47 +77,51 @@ const Game = () => {
 	// const { canShowToast, resetCooldown } = useToastCooldown(TOAST_DURATION);
 	const router = useRouter();
 
-useShortcut(
-	{
-		escape: () => {
-			if ( activeModal === "winner") return;
+	useShortcut(
+		{
+			escape: () => {
+				if (activeModal === "winner") return;
 
-			if (activeModal) return setActiveModal(null);
-			return setIsMenuOpen(false);
-		},
+				if (activeModal) return setActiveModal(null);
+				return setIsMenuOpen(false);
+			},
 
-		m: () => {
-			if (activeModal === "winner") return;
-			setActiveModal("exitConfirmation");
-		},
+			m: () => {
+				if (activeModal === "winner") return;
+				setActiveModal("exitConfirmation");
+			},
 
-		r: () => {
-			if (activeModal === "winner") return;
-			setActiveModal("resetConfirmation");
-		},
+			r: () => {
+				if (activeModal === "winner") return;
+				setActiveModal("resetConfirmation");
+			},
 
-		c: () => {
-			if (activeModal === "winner") return;
-			setActiveModal(prev => prev === "boardConfig" ? null : "boardConfig");
-		},
+			c: () => {
+				if (activeModal === "winner") return;
+				setActiveModal((prev) =>
+					prev === "boardConfig" ? null : "boardConfig",
+				);
+			},
 
-		s: () => {
-			if ( activeModal === "winner") return;
-			setActiveModal(prev => prev === "soundConfig" ? null : "soundConfig");
-		},
+			s: () => {
+				if (activeModal === "winner") return;
+				setActiveModal((prev) =>
+					prev === "soundConfig" ? null : "soundConfig",
+				);
+			},
 
-		d: () => {
-			if (activeModal === "winner") return;
-			setActiveModal(prev => prev === "difficulty" ? null : "difficulty");
-		},
+			d: () => {
+				if (activeModal === "winner") return;
+				setActiveModal((prev) => (prev === "difficulty" ? null : "difficulty"));
+			},
 
-		q: () => {
-			if (activeModal === "winner") return;
-			setActiveModal(prev => prev === "shortcut" ? null : "shortcut");
+			q: () => {
+				if (activeModal === "winner") return;
+				setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut"));
+			},
 		},
-	},
-	isMenuOpen
-);
+		isMenuOpen,
+	);
 
 	const initGame = async (
 		num: BoardNumber,

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -77,29 +77,47 @@ const Game = () => {
 	// const { canShowToast, resetCooldown } = useToastCooldown(TOAST_DURATION);
 	const router = useRouter();
 
-	useShortcut(
-		{
-			escape: () => {
-				if (activeModal) return setActiveModal(null);
-				return setIsMenuOpen(false);
-			},
-			m: () => setActiveModal("exitConfirmation"),
-			r: () => setActiveModal("resetConfirmation"),
-			c: () =>
-				setActiveModal((prev) =>
-					prev === "boardConfig" ? null : "boardConfig",
-				),
-			s: () =>
-				setActiveModal((prev) =>
-					prev === "soundConfig" ? null : "soundConfig",
-				),
-			d: () =>
-				setActiveModal((prev) => (prev === "difficulty" ? null : "difficulty")),
-			q: () =>
-				setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut")),
+useShortcut(
+	{
+		escape: () => {
+			if ( activeModal === "winner") return;
+
+			if (activeModal) return setActiveModal(null);
+			return setIsMenuOpen(false);
 		},
-		isMenuOpen, // disabled condition
-	);
+
+		m: () => {
+			if (activeModal === "winner") return;
+			setActiveModal("exitConfirmation");
+		},
+
+		r: () => {
+			if (activeModal === "winner") return;
+			setActiveModal("resetConfirmation");
+		},
+
+		c: () => {
+			if (activeModal === "winner") return;
+			setActiveModal(prev => prev === "boardConfig" ? null : "boardConfig");
+		},
+
+		s: () => {
+			if ( activeModal === "winner") return;
+			setActiveModal(prev => prev === "soundConfig" ? null : "soundConfig");
+		},
+
+		d: () => {
+			if (activeModal === "winner") return;
+			setActiveModal(prev => prev === "difficulty" ? null : "difficulty");
+		},
+
+		q: () => {
+			if (activeModal === "winner") return;
+			setActiveModal(prev => prev === "shortcut" ? null : "shortcut");
+		},
+	},
+	isMenuOpen
+);
 
 	const initGame = async (
 		num: BoardNumber,

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -67,6 +67,7 @@ const Game = () => {
 	const [isUpdatingDifficulty, setIsUpdatingDifficulty] =
 		useState<boolean>(false);
 	const [activeModal, setActiveModal] = useState<ComputerButtonModalType>(null);
+	const [hasMoveHappened, setHasMoveHappened] = useState(false);
 
 	const { sfxMute } = useSound();
 	const Coins = useCoins((state) => state.coins);
@@ -88,12 +89,16 @@ const Game = () => {
 
 			m: () => {
 				if (activeModal === "winner") return;
-				setActiveModal("exitConfirmation");
+				setActiveModal((prev) =>
+					prev === "exitConfirmation" ? null : "exitConfirmation",
+				);
 			},
 
 			r: () => {
-				if (activeModal === "winner") return;
-				setActiveModal("resetConfirmation");
+				if (activeModal === "winner" || !hasMoveHappened) return;
+				setActiveModal((prev) =>
+					prev === "resetConfirmation" ? null : "resetConfirmation",
+				);
 			},
 
 			c: () => {
@@ -162,6 +167,9 @@ const Game = () => {
 	const handleMove = async (boardIndex: number, cellIndex: number) => {
 		if (isProcessing) return;
 		setIsProcessing(true);
+		if (!hasMoveHappened) {
+			setHasMoveHappened(true);
+		}
 		try {
 			if (user) {
 				const data = await makeMove(
@@ -198,6 +206,7 @@ const Game = () => {
 	};
 
 	const handleReset = async () => {
+		setHasMoveHappened(false);
 		if (isResetting) return;
 		setIsResetting(true);
 

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -206,7 +206,6 @@ const Game = () => {
 	};
 
 	const handleReset = async () => {
-		setHasMoveHappened(false);
 		if (isResetting) return;
 		setIsResetting(true);
 
@@ -214,6 +213,7 @@ const Game = () => {
 			if (user) {
 				const data = await resetGame(sessionId, await user.getIdToken());
 				if (data.success) {
+					setHasMoveHappened(false);
 					setBoards(data.gameState.boards);
 					setCurrentPlayer(data.gameState.currentPlayer);
 					setGameHistory(data.gameState.gameHistory);

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -20,6 +20,7 @@ import PlayerTurnTitle from "@/components/ui/Title/PlayerTurnTitle";
 import StatLabel from "@/components/ui/Title/StatLabel";
 // import { TOAST_DURATION } from "@/constants/toast";
 import BoardConfigModal from "@/modals/BoardConfigModal";
+import ConfirmationModal from "@/modals/ConfirmationModal";
 import DifficultyModal from "@/modals/DifficultyModal";
 import ShortcutModal from "@/modals/ShortcutModal";
 import SoundConfigModal from "@/modals/SoundConfigModal";
@@ -43,7 +44,6 @@ import type {
 	ComputerButtonModalType,
 	DifficultyLevel,
 } from "@/services/types";
-import ConfirmationModal from "@/modals/ConfirmationModal";
 
 const Game = () => {
 	const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);

--- a/src/app/vsComputer/page.tsx
+++ b/src/app/vsComputer/page.tsx
@@ -43,6 +43,7 @@ import type {
 	ComputerButtonModalType,
 	DifficultyLevel,
 } from "@/services/types";
+import ConfirmationModal from "@/modals/ConfirmationModal";
 
 const Game = () => {
 	const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
@@ -82,8 +83,8 @@ const Game = () => {
 				if (activeModal) return setActiveModal(null);
 				return setIsMenuOpen(false);
 			},
-			m: () => router.push("/"),
-			r: () => handleReset(),
+			m: () => setActiveModal("exitConfirmation"),
+			r: () => setActiveModal("resetConfirmation"),
 			c: () =>
 				setActiveModal((prev) =>
 					prev === "boardConfig" ? null : "boardConfig",
@@ -503,6 +504,27 @@ const Game = () => {
 			<SoundConfigModal
 				visible={activeModal === "soundConfig"}
 				onClose={() => setActiveModal(null)}
+			/>
+			<ConfirmationModal
+				visible={activeModal === "resetConfirmation"}
+				title="Reset Game?"
+				message="Are you sure you want to reset the current game?"
+				onConfirm={() => {
+					handleReset();
+					setActiveModal(null);
+				}}
+				onCancel={() => setActiveModal(null)}
+				confirmText="Yes, Reset"
+			/>
+			<ConfirmationModal
+				visible={activeModal === "exitConfirmation"}
+				title="Exit to Menu?"
+				message="Are you sure you want to exit? Your current game will be lost."
+				onConfirm={() => {
+					router.push("/");
+				}}
+				onCancel={() => setActiveModal(null)}
+				confirmText="Yes, Exit"
 			/>
 		</GameLayout>
 	);

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -52,7 +52,7 @@ const Game = () => {
 	useShortcut(
 		{
 			escape: () => {
-				if (!initialSetupDone && !gameStarted) return;
+				if (!initialSetupDone && !gameStarted || activeModal === "winner") return;
 				if (activeModal) return setActiveModal(null);
 				return setIsMenuOpen(false);
 			},
@@ -62,7 +62,8 @@ const Game = () => {
 				setActiveModal("exitConfirmation");
 			},
 			r: () => {
-				if (!initialSetupDone || !hasMoveHappened) return;
+				if (!initialSetupDone || !hasMoveHappened || activeModal === "winner")
+					return;
 				// resetGame(numberOfBoards, boardSize);
 				setActiveModal("resetConfirmation");
 			},
@@ -71,19 +72,19 @@ const Game = () => {
 				setActiveModal((prev) => (prev === "names" ? null : "names"));
 			},
 			c: () => {
-				if (!initialSetupDone) return;
+				if (!initialSetupDone || activeModal === "winner") return;
 				setActiveModal((prev) =>
 					prev === "boardConfig" ? null : "boardConfig",
 				);
 			},
 			s: () => {
-				if (!initialSetupDone) return;
+				if (!initialSetupDone || activeModal === "winner") return;
 				setActiveModal((prev) =>
 					prev === "soundConfig" ? null : "soundConfig",
 				);
 			},
 			q: () => {
-				if (!initialSetupDone) return;
+				if (!initialSetupDone|| activeModal === "winner") return;
 				setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut"));
 			},
 		},

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -60,7 +60,8 @@ const Game = () => {
 			m: () => {
 				if (!initialSetupDone || activeModal === "winner") return;
 				setActiveModal((prev) =>
-					prev === "exitConfirmation" ? null : "exitConfirmation");
+					prev === "exitConfirmation" ? null : "exitConfirmation",
+				);
 			},
 			r: () => {
 				if (!initialSetupDone || !hasMoveHappened || activeModal === "winner")

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -65,6 +65,7 @@ const Game = () => {
 			r: () => {
 				if (!initialSetupDone || !hasMoveHappened || activeModal === "winner")
 					return;
+				setHasMoveHappened(false);
 				// resetGame(numberOfBoards, boardSize);
 				setActiveModal("resetConfirmation");
 			},

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -69,7 +69,7 @@ const Game = () => {
 				setActiveModal("resetConfirmation");
 			},
 			n: () => {
-				if (!initialSetupDone) return;
+				if (!initialSetupDone || activeModal === "winner") return;
 				setActiveModal((prev) => (prev === "names" ? null : "names"));
 			},
 			c: () => {

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -59,15 +59,16 @@ const Game = () => {
 			},
 			m: () => {
 				if (!initialSetupDone || activeModal === "winner") return;
-				// router.push("/");
-				setActiveModal("exitConfirmation");
+				setActiveModal((prev) =>
+					prev === "exitConfirmation" ? null : "exitConfirmation");
 			},
 			r: () => {
 				if (!initialSetupDone || !hasMoveHappened || activeModal === "winner")
 					return;
-				setHasMoveHappened(false);
-				// resetGame(numberOfBoards, boardSize);
-				setActiveModal("resetConfirmation");
+
+				setActiveModal((prev) =>
+					prev === "resetConfirmation" ? null : "resetConfirmation",
+				);
 			},
 			n: () => {
 				if (!initialSetupDone || activeModal === "winner") return;
@@ -131,6 +132,7 @@ const Game = () => {
 		setBoards(initialBoards);
 		setCurrentPlayer(1);
 		setActiveModal(null);
+		setHasMoveHappened(false);
 	};
 
 	const handleBoardConfigChange = (num: BoardNumber, size: BoardSize) => {

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -43,6 +43,7 @@ const Game = () => {
 	const [initialSetupDone, setInitialSetupDone] = useState<boolean>(false);
 	const [activeModal, setActiveModal] =
 		useState<PlayerButtonModalType>("names");
+	const [hasMoveHappened, setHasMoveHappened] = useState(false);
 
 	const { sfxMute } = useSound();
 	const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
@@ -56,12 +57,12 @@ const Game = () => {
 				return setIsMenuOpen(false);
 			},
 			m: () => {
-				if (!initialSetupDone) return;
+				if (!initialSetupDone || activeModal === "winner") return;
 				// router.push("/");
 				setActiveModal("exitConfirmation");
 			},
 			r: () => {
-				if (!initialSetupDone) return;
+				if (!initialSetupDone || !hasMoveHappened) return;
 				// resetGame(numberOfBoards, boardSize);
 				setActiveModal("resetConfirmation");
 			},
@@ -90,6 +91,9 @@ const Game = () => {
 	);
 
 	const makeMove = (boardIndex: number, cellIndex: number) => {
+		if (!hasMoveHappened) {
+			setHasMoveHappened(true);
+		}
 		if (
 			boards[boardIndex][cellIndex] !== "" ||
 			isBoardDead(boards[boardIndex], boardSize)

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -52,7 +52,8 @@ const Game = () => {
 	useShortcut(
 		{
 			escape: () => {
-				if (!initialSetupDone && !gameStarted || activeModal === "winner") return;
+				if ((!initialSetupDone && !gameStarted) || activeModal === "winner")
+					return;
 				if (activeModal) return setActiveModal(null);
 				return setIsMenuOpen(false);
 			},
@@ -84,7 +85,7 @@ const Game = () => {
 				);
 			},
 			q: () => {
-				if (!initialSetupDone|| activeModal === "winner") return;
+				if (!initialSetupDone || activeModal === "winner") return;
 				setActiveModal((prev) => (prev === "shortcut" ? null : "shortcut"));
 			},
 		},

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -28,6 +28,7 @@ import type {
 	BoardState,
 	PlayerButtonModalType,
 } from "@/services/types";
+import ConfirmationModal from "@/modals/ConfirmationModal";
 
 const Game = () => {
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -56,11 +57,13 @@ const Game = () => {
 			},
 			m: () => {
 				if (!initialSetupDone) return;
-				router.push("/");
+				// router.push("/");
+				setActiveModal("exitConfirmation");
 			},
 			r: () => {
 				if (!initialSetupDone) return;
-				resetGame(numberOfBoards, boardSize);
+				// resetGame(numberOfBoards, boardSize);
+				setActiveModal("resetConfirmation");
 			},
 			n: () => {
 				if (!initialSetupDone) return;
@@ -250,6 +253,27 @@ const Game = () => {
 			<ShortcutModal
 				visible={activeModal === "shortcut"}
 				onClose={() => setActiveModal(null)}
+			/>
+			<ConfirmationModal
+				visible={activeModal === "resetConfirmation"}
+				title="Reset Game?"
+				message="Are you sure you want to reset the current game?"
+				onConfirm={() => {
+					resetGame(numberOfBoards, boardSize);
+					setActiveModal(null);
+				}}
+				onCancel={() => setActiveModal(null)}
+				confirmText="Yes, Reset"
+			/>
+			<ConfirmationModal
+				visible={activeModal === "exitConfirmation"}
+				title="Exit to Menu?"
+				message="Are you sure you want to exit? Your current game will be lost."
+				onConfirm={() => {
+					router.push("/");
+				}}
+				onCancel={() => setActiveModal(null)}
+				confirmText="Yes, Exit"
 			/>
 		</GameLayout>
 	);

--- a/src/app/vsPlayer/page.tsx
+++ b/src/app/vsPlayer/page.tsx
@@ -15,6 +15,7 @@ import SettingOverlay from "@/components/ui/Containers/Settings/SettingOverlay";
 import GameLayout from "@/components/ui/Layout/GameLayout";
 import PlayerTurnTitle from "@/components/ui/Title/PlayerTurnTitle";
 import BoardConfigModal from "@/modals/BoardConfigModal";
+import ConfirmationModal from "@/modals/ConfirmationModal";
 import PlayerNamesModal from "@/modals/PlayerNamesModal";
 import ShortcutModal from "@/modals/ShortcutModal";
 import SoundConfigModal from "@/modals/SoundConfigModal";
@@ -28,7 +29,6 @@ import type {
 	BoardState,
 	PlayerButtonModalType,
 } from "@/services/types";
-import ConfirmationModal from "@/modals/ConfirmationModal";
 
 const Game = () => {
 	const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/modals/ConfirmationModal.tsx
+++ b/src/modals/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-/** biome-ignore-all lint/a11y/useButtonType: <explanation> */
+
 import ModalOverlay from "@/components/ui/Overlays/ModalOverlay";
 
 interface ConfirmationModalProps {
@@ -29,11 +29,13 @@ const ConfirmationModal = ({
 				<p className="my-6 text-center text-lg text-white">{message}</p>
 				<div className="flex justify-center gap-4">
 					<button
+                        type="button"
 						className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
 						onClick={onConfirm}>
 						{confirmText}
 					</button>
 					<button
+                        type="button"
 						className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
 						onClick={onCancel}>
 						{cancelText}

--- a/src/modals/ConfirmationModal.tsx
+++ b/src/modals/ConfirmationModal.tsx
@@ -1,0 +1,47 @@
+/** biome-ignore-all lint/a11y/useButtonType: <explanation> */
+import ModalOverlay from "@/components/ui/Overlays/ModalOverlay";
+
+interface ConfirmationModalProps {
+	visible: boolean;
+	title: string;
+	message: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+	confirmText?: string;
+	cancelText?: string;
+}
+
+const ConfirmationModal = ({
+	visible,
+	title,
+	message,
+	onConfirm,
+	onCancel,
+	confirmText = "Confirm",
+	cancelText = "Cancel",
+}: ConfirmationModalProps) => {
+	if (!visible) return null;
+
+	return (
+		<ModalOverlay>
+			<div className="bg-black w-full max-w-md p-6">
+				<h1 className="text-red-500 text-4xl mb-2 text-center">{title}</h1>
+				<p className="my-6 text-center text-lg text-white">{message}</p>
+				<div className="flex justify-center gap-4">
+					<button
+						className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
+						onClick={onConfirm}>
+						{confirmText}
+					</button>
+					<button
+						className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
+						onClick={onCancel}>
+						{cancelText}
+					</button>
+				</div>
+			</div>
+		</ModalOverlay>
+	);
+};
+
+export default ConfirmationModal;

--- a/src/modals/ConfirmationModal.tsx
+++ b/src/modals/ConfirmationModal.tsx
@@ -1,4 +1,3 @@
-
 import ModalOverlay from "@/components/ui/Overlays/ModalOverlay";
 
 interface ConfirmationModalProps {
@@ -29,13 +28,13 @@ const ConfirmationModal = ({
 				<p className="my-6 text-center text-lg text-white">{message}</p>
 				<div className="flex justify-center gap-4">
 					<button
-                        type="button"
+						type="button"
 						className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
 						onClick={onConfirm}>
 						{confirmText}
 					</button>
 					<button
-                        type="button"
+						type="button"
 						className="bg-blue-600 hover:bg-blue-700 text-white px-12 py-3 text-xl w-full mt-4"
 						onClick={onCancel}>
 						{cancelText}

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -371,6 +371,8 @@ export type PlayerButtonModalType =
 	| "boardConfig"
 	| "soundConfig"
 	| "shortcut"
+	| "resetConfirmation"
+	| "exitConfirmation"
 	| null;
 
 export type ComputerButtonModalType =
@@ -379,6 +381,8 @@ export type ComputerButtonModalType =
 	| "soundConfig"
 	| "difficulty"
 	| "shortcut"
+	| "resetConfirmation"
+	| "exitConfirmation"
 	| null;
 
 export type MenuModalType = "soundConfig" | "shortcut" | "tutorial" | null;


### PR DESCRIPTION
## Description

### Purpose of this PR:

### How to test this PR manually:

### Related Issue
closes #307 
## Category (replace the empty space inside brackets with x for tick)
- [ ] Bug
- [ ] Refactor
- [x] Enhancement/New Feature
- [ ] Tests
- [ ] Documentation

## Checklist 
- [x] I have read and reviewed each line of my Git/File Differences for this PR very carefully and I clearly understand the reason behind the code changes and decisions I have made
- [x] This PR is short and cant be decomposed further without breaking consistency (check ../docs/SHORT_PR.md for more information)
- [x] I have manually tested all the changes and indirect impacts these changes could have made
- [] I have added/updated automated testing scripts (check ../docs/TESTS_FOR_PR.md for more information)
- [ ] I will keep my branch updated with main till this branch doesn't get merged
- [ ] Documentations updated if applicable
- [ ] Code reviewed for accessibility
- [x] I will check the review made by coderabbit (both actionable and nitpick) and will respond with atleast a short comment of why I disagree with it
- [x] I understand maintainers might not be able to help with general doubts like git, tech stack etc
- [x] I will post the doubts regarding repository/project in Discussions tab only, so that fellow contributors could help me
- [x] I understand that doubts related to an issue or PR will be made as comment to the same.
- [x] I do not have any existing open PR pending to be merged
- [ ] If I am making this PR as a part of any competition then I will name it and mention e-mail id registered with that competition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation dialogs added for Reset and Exit in both player-vs-player and player-vs-computer modes.
  * Reset confirmation only appears after a move has occurred.

* **Behavior Changes**
  * Keyboard shortcuts updated: "m" = Exit, "r" = Reset (gated by moves), Escape closes dialogs unless a winner dialog is active.
  * Certain shortcuts are disabled while a winner dialog is shown.

* **Refactor**
  * Shortcut actions now route through confirmation flows instead of immediate actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->