### PR TITLE
Feature/vsplayer empty validation

### DIFF
--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -9,6 +9,7 @@ export const TOAST_IDS = {
 	// Player name modal
 	PlayerNames: {
 		Duplicate: "player-names/duplicate",
+		Empty: "player-names/empty",
 	},
 
 	// Payment related toasts

--- a/src/modals/PlayerNamesModal.tsx
+++ b/src/modals/PlayerNamesModal.tsx
@@ -50,6 +50,19 @@ const PlayerNamesModal = ({
 			setPlayer1(finalPlayer1);
 			setPlayer2(finalPlayer2);
 
+			// Run duplicate validation on final autofilled names
+			if (finalPlayer1.toLowerCase() === finalPlayer2.toLowerCase()) {
+				if (canShowToast()) {
+					toast("Player 1 and Player 2 cannot have the same name.", {
+						toastId: TOAST_IDS.PlayerNames.Duplicate,
+						autoClose: TOAST_DURATION,
+						onClose: resetCooldown,
+					});
+					triggerToastCooldown();
+				}
+				return;
+			}
+
 			onSubmit(finalPlayer1, finalPlayer2);
 			return;
 		}

--- a/src/modals/PlayerNamesModal.tsx
+++ b/src/modals/PlayerNamesModal.tsx
@@ -30,21 +30,47 @@ const PlayerNamesModal = ({
 	}, [initialNames]);
 
 	const handleSubmit = () => {
-		if (!canShowToast()) return;
+		const trimmedPlayer1 = player1.trim();
+		const trimmedPlayer2 = player2.trim();
 
-		if (player1.trim().toLowerCase() === player2.trim().toLowerCase()) {
-			toast("Player 1 and Player 2 cannot have the same name.", {
-				toastId: TOAST_IDS.PlayerNames.Duplicate,
-				autoClose: TOAST_DURATION,
-				onClose: resetCooldown, // reset cooldown if closed early
-			});
-			triggerToastCooldown();
+		// Empty name validation
+		if (!trimmedPlayer1 || !trimmedPlayer2) {
+			if (canShowToast()) {
+				toast("Player name cannot be empty.", {
+					toastId: TOAST_IDS.PlayerNames.Empty,
+					autoClose: TOAST_DURATION,
+					onClose: resetCooldown,
+				});
+				triggerToastCooldown();
+			}
+
+			const finalPlayer1 = trimmedPlayer1 || "Player 1";
+			const finalPlayer2 = trimmedPlayer2 || "Player 2";
+
+			setPlayer1(finalPlayer1);
+			setPlayer2(finalPlayer2);
+
+			onSubmit(finalPlayer1, finalPlayer2);
 			return;
 		}
+
+		// Duplicate name validation
+		if (trimmedPlayer1.toLowerCase() === trimmedPlayer2.toLowerCase()) {
+			if (canShowToast()) {
+				toast("Player 1 and Player 2 cannot have the same name.", {
+					toastId: TOAST_IDS.PlayerNames.Duplicate,
+					autoClose: TOAST_DURATION,
+					onClose: resetCooldown,
+				});
+				triggerToastCooldown();
+			}
+			return;
+		}
+
 		toast.dismiss(TOAST_IDS.PlayerNames.Duplicate);
 		resetCooldown();
 
-		onSubmit(player1 || "Player 1", player2 || "Player 2");
+		onSubmit(trimmedPlayer1, trimmedPlayer2);
 	};
 
 	if (!visible) return null;

--- a/src/modals/PlayerNamesModal.tsx
+++ b/src/modals/PlayerNamesModal.tsx
@@ -68,6 +68,7 @@ const PlayerNamesModal = ({
 		}
 
 		toast.dismiss(TOAST_IDS.PlayerNames.Duplicate);
+		toast.dismiss(TOAST_IDS.PlayerNames.Empty);
 		resetCooldown();
 
 		onSubmit(trimmedPlayer1, trimmedPlayer2);


### PR DESCRIPTION
## Description

### Purpose of this PR:
This PR adds validation for empty player names in **Play vs Player** mode.

- Prevents starting the game if either player name is empty or contains only whitespace.
- Shows a toast notification when validation fails.
- Automatically fills default names ("Player 1", "Player 2") if fields are empty.

This improves UX clarity and prevents accidental game starts with blank names.

### How to test this PR manually:
1. Run `pnpm dev`
2. Open `http://localhost:3000`
3. Click **Play vs Player**
4. Test the following cases:

- Case 1: Both names empty → Toast appears, names autofill, game starts with Player1 and Player2
- Case 2: One name empty → Toast appears, empty field autofills, game starts with <filled_username> and Player2
- Case 3: Duplicate names → Duplicate name toast appears, game doesnt starts
- Case 4: Valid different names → Game starts normally

### Related Issue
Closes #410 

## Category (replace the empty space inside brackets with x for tick)
- [ ] Bug
- [ ] Refactor
- [x] Enhancement/New Feature
- [ ] Tests
- [ ] Documentation

## Checklist 
- [ ] I have read and reviewed each line of my Git/File Differences for this PR very carefully and I clearly understand the reason behind the code changes and decisions I have made
- [ ] This PR is short and cant be decomposed further without breaking consistency (check ../docs/SHORT_PR.md for more information)
- [x] I have manually tested all the changes and indirect impacts these changes could have made
- [ ] I have added/updated automated testing scripts (check ../docs/TESTS_FOR_PR.md for more information)
- [x] I will keep my branch updated with main till this branch doesn't get merged
- [x] Documentations updated if applicable
- [x] Code reviewed for accessibility
- [x] I will check the review made by coderabbit (both actionable and nitpick) and will respond with atleast a short comment of why I disagree with it
- [x] I understand maintainers might not be able to help with general doubts like git, tech stack etc
- [x] I will post the doubts regarding repository/project in Discussions tab only, so that fellow contributors could help me
- [x] I understand that doubts related to an issue or PR will be made as comment to the same.
- [ ] I do not have any existing open PR pending to be merged
- [ ] If I am making this PR as a part of any competition then I will name it and mention e-mail id registered with that competition

## Screenshots (if applicable)
<img width="1470" height="956" alt="Screenshot 2026-02-14 at 10 20 27" src="https://github.com/user-attachments/assets/7e7cd5cc-3e54-45a9-a7ed-70fd5bef4aba" />
<img width="1470" height="956" alt="Screenshot 2026-02-14 at 10 19 55" src="https://github.com/user-attachments/assets/5f1be017-174f-4d50-b01b-8193718b3088" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent empty player names and auto-fill defaults when missing
  * Prevent duplicate player names (case-insensitive)
  * Trim leading/trailing whitespace from player names before submission
  * New toast notification for empty-name validation and clearer toast behavior for validation failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->