### PR TITLE
[test]: T2 — Two distinct toasts should stack properly when triggered in quick succession

### DIFF
--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -33,22 +33,22 @@ describe("Toast Tests", () => {
 			toast.error("Error two: action B failed");
 		});
 
-		// Both toasts must be visible
+		// Wait for both toasts to appear in the DOM (works with portals)
 		const toastOne = await screen.findByText("Error one: action A failed");
 		const toastTwo = await screen.findByText("Error two: action B failed");
 		expect(toastOne).toBeInTheDocument();
 		expect(toastTwo).toBeInTheDocument();
 
-		// Must be exactly two toasts in the container
-		const allToasts = document.querySelectorAll(".Toastify__toast");
+		// role="alert" is assigned by react-toastify to every toast
+		const allToasts = await screen.findAllByRole("alert");
 		expect(allToasts).toHaveLength(2);
 
-		// Neither toast contains the other — they are stacked as siblings, not nested
-		const [first, second] = Array.from(allToasts);
+		// Neither toast contains the other — stacked as siblings, not nested
+		const [first, second] = allToasts;
 		expect(first).not.toContainElement(second as HTMLElement);
 		expect(second).not.toContainElement(first as HTMLElement);
 
-		// They must carry different content — truly distinct toasts
+		// Truly distinct — different text content
 		expect(first.textContent).not.toBe(second.textContent);
 	});
 });

--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -1,7 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { toast } from "react-toastify";
 import { afterEach, describe, expect, it } from "vitest";
-
 import { CustomToastContainer } from "@/widgets/toast-surface/ui/ToastSurface";
 
 describe("Toast Tests", () => {
@@ -13,21 +12,43 @@ describe("Toast Tests", () => {
 
 	it("T1 : shows a toast with correct text and styling when triggered", async () => {
 		render(<CustomToastContainer />);
-
 		act(() => {
 			toast("Hello Toast Test");
 		});
-
 		const toastText = await screen.findByText("Hello Toast Test");
 		expect(toastText).toBeInTheDocument();
-
 		const toastWrapper =
 			toastText.closest(".Toastify__toast") ?? toastText.closest("div");
 		expect(toastWrapper).toBeTruthy();
-
 		const expected = ["bg-panel", "text-cream", "relative", "text-center"];
 		for (const cls of expected) expect(toastWrapper?.className).toContain(cls);
-
 		expect(screen.queryAllByText("Hello Toast Test")).toHaveLength(1);
+	});
+
+	it("T2 : two distinct toasts appear and stack properly when triggered in quick succession", async () => {
+		render(<CustomToastContainer />);
+
+		act(() => {
+			toast.error("Error one: action A failed");
+			toast.error("Error two: action B failed");
+		});
+
+		// Both toasts must be visible
+		const toastOne = await screen.findByText("Error one: action A failed");
+		const toastTwo = await screen.findByText("Error two: action B failed");
+		expect(toastOne).toBeInTheDocument();
+		expect(toastTwo).toBeInTheDocument();
+
+		// Must be exactly two toasts in the container
+		const allToasts = document.querySelectorAll(".Toastify__toast");
+		expect(allToasts).toHaveLength(2);
+
+		// Neither toast contains the other — they are stacked as siblings, not nested
+		const [first, second] = Array.from(allToasts);
+		expect(first).not.toContainElement(second as HTMLElement);
+		expect(second).not.toContainElement(first as HTMLElement);
+
+		// They must carry different content — truly distinct toasts
+		expect(first.textContent).not.toBe(second.textContent);
 	});
 });

--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -25,7 +25,7 @@ describe("Toast Tests", () => {
 		expect(screen.queryAllByText("Hello Toast Test")).toHaveLength(1);
 	});
 
-	it("T2 : two distinct toasts appear and stack properly when triggered in quick succession", async () => {
+	it("two distinct toasts appear and stack properly when triggered in quick succession", async () => {
 		render(<CustomToastContainer />);
 
 		act(() => {


### PR DESCRIPTION
Closes #432

## What this PR does
Adds test case T2 to the existing toast test suite in `__tests__/toast.test.tsx`.

## Changes
- `__tests__/toast.test.tsx` — added T2 `it()` block inside the existing `describe("Toast Tests")` suite. No other files were modified.

## Test case T2
**Precondition:** App is running (`CustomToastContainer` mounted in JSDOM)

**Steps:**
1. Render `<CustomToastContainer />`
2. Trigger two different `toast.error()` calls inside a single `act()` in quick succession

**Assertions:**
- Both toast messages are present in the DOM
- Exactly 2 `.Toastify__toast` nodes are rendered
- Neither toast contains the other (sibling nodes, not nested)
- Both toasts have different text content (truly distinct)

**Result:** ✅ Two distinct toasts appear and stack properly without overlap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded toast notification tests: added coverage verifying multiple toasts render independently (both present, siblings not nested, distinct contents).
  * Improved test reliability for async/portal behavior by wrapping toast triggers in proper async handling and strengthening assertions for appearance and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->