### PR TITLE
Fixed the shortcut issue in home page

### DIFF
--- a/src/widgets/home-menu/ui/HomeMenu.tsx
+++ b/src/widgets/home-menu/ui/HomeMenu.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useGlobalModal } from "@/features/manage-global-modal/model/globalModalStore";
 import { useNavigateGameMode } from "@/features/navigate-game-mode/model/useNavigateGameMode";
+import { useShortcut } from "@/features/use-keyboard-shortcuts/model/useShortcut";
 import GameModeList from "@/widgets/game-mode-list/ui/GameModeList";
 import HomeFooterHint from "@/widgets/home-footer-hint/ui/HomeFooterHint";
 import { GAME_MODES } from "@/widgets/home-menu/constants";
@@ -9,7 +11,27 @@ import { MenuLayout } from "@/widgets/menu-layout/ui/MenuLayout";
 
 const Menu = () => {
 	const startGame = useNavigateGameMode();
-
+	const { activeModal, openModal, closeModal } = useGlobalModal();
+	useShortcut(
+		{
+			escape: () => {
+				if (activeModal) return closeModal();
+			},
+			s: () => {
+				activeModal === "soundConfig" ? closeModal() : openModal("soundConfig");
+			},
+			q: () => {
+				activeModal === "shortcut" ? closeModal() : openModal("shortcut");
+			},
+			p: () => {
+				activeModal === "profile" ? closeModal() : openModal("profile");
+			},
+			t: () => {
+				activeModal === "tutorial" ? closeModal() : openModal("tutorial");
+			},
+		},
+		false,
+	);
 	return (
 		<MenuLayout>
 			<div className="flex flex-col items-center justify-center min-h-screen px-6 py-12">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts on the Home menu to quickly manage key modal panels.
  * Pressing `Esc` now closes any open modal, and `S`, `Q`, `P`, and `T` toggle the sound, shortcut, profile, and tutorial panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->