### PR TITLE
feat(whitelistImageKit)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,11 @@ const nextConfig: NextConfig = {
 				hostname: "lh3.googleusercontent.com",
 				pathname: "/**",
 			},
+			{
+				protocol: "https",
+				hostname: "ik.imagekit.io",
+				pathname: "/notakto/**",
+			},
 		],
 	},
 	compiler: {


### PR DESCRIPTION
whitelist imagekit image url in next config so that nextjs could allow rendering images with this host+pathname


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled secure remote images from ImageKit within the supported `/notakto/` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->