### PR TITLE
Revert "Whitelist image kit"

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
 			{
 				protocol: "https",
 				hostname: "ik.imagekit.io",
-				pathname: "/**",
+				pathname: "/notakto/**",
 			},
 		],
 	},


### PR DESCRIPTION
Reverts notakto/notakto-website#450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Configuration**
  * Restricted optimized images from the ImageKit host to approved `/notakto/` paths.
  * Improved control over which remote image URLs the application can process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->